### PR TITLE
Support hhvm 4.71

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -13,3 +13,5 @@ hackfmt.tabs=true
 hackfmt.line_width=120
 hackfmt.add_trailing_commas=true
 user_attributes=
+allowed_decl_fixme_codes=2053,4047
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4047,4104,4107,4108,4110,4128,4135,4188,4240,4323

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"require": {
 		"hhvm/hhast": "^4.33.5",
 		"facebook/fbexpect": "^2.7.3",
-		"hhvm/hhvm-autoload": "^2.0",
+		"hhvm/hhvm-autoload": "^2.0|^3.0",
 		"hhvm/hacktest": "^2.0.0",
 		"hhvm/hsl": "^4.36.0",
 		"hhvm/hsl-experimental": "^4.37.3",

--- a/src/AttrDef/CSS/Number.hack
+++ b/src/AttrDef/CSS/Number.hack
@@ -42,6 +42,7 @@ class HTMLPurifier_AttrDef_CSS_Number extends HTMLPurifier\HTMLPurifier_AttrDef 
                 // FALLTHROUGH
             case '+':
                 $number = Str\slice($number, 1);
+            default: // Do nothing (required in newer hhvm versions)
         }
 
         if (\ctype_digit($number)) {


### PR DESCRIPTION
###  Summary

This PR extends runtime support to hhvm 4.71.

Adds two directives to hhconfig to allow HH_FIXME's
Adds an empty default to a switch statement (newer hhvm versions warn when no case in a switch matched)
Allow hhvm/hhvm-autoload version 3

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https:/github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https:/slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

~* [ ] I've written tests to cover the new code and functionality included in this PR.~
_No code changes were made._

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https:/cla-assistant.io/slackhq/htmlsanitizer-hack).
