### PR TITLE
Add a missing `/` to links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,8 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 ### Requirements (place an `x` in each `[ ]`)
 
-* [ ] I've read and understood the [Contributing Guidelines](https:/github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
-* [ ] I've read and agree to the [Code of Conduct](https:/slackhq.github.io/code-of-conduct).
+* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
+* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
 
 > The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)
 
@@ -13,4 +13,4 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 > The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io
 
-* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https:/cla-assistant.io/slackhq/htmlsanitizer-hack).
+* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/htmlsanitizer-hack).


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers

This makes the links functional, except for the `Contributing Guidelines`, since they are still missing in the project.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https:/github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https:/slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

~* [ ] I've written tests to cover the new code and functionality included in this PR.~
_No code changes were made._

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https:/cla-assistant.io/slackhq/htmlsanitizer-hack).
