### PR TITLE
Make the rich formatting test pass

### DIFF
--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -100,12 +100,19 @@ class HTMLPurifierTest extends HackTest {
 </table>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<table><caption>
+		expect($clean_html)->toEqual('<table>
+  <caption>
     Cool table
   </caption>
-  <tfoot><tr><th>I can do so much!</th>
-    </tr></tfoot><tbody><tr><td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
-  </tr></tbody></table>');
+  <tfoot>
+    <tr>
+      <th>I can do so much!</th>
+    </tr>
+  </tfoot>
+  <tbody><tr>
+    <td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
+  </tr>
+</tbody></table>');
 	}
 
 	public function testDOM() : void {


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

Make the rich formatting test pass

This test was failing because of whitespace changes.
The test name led me to believe that whitespace should be preserved.
The expected output was missing the formatting.
Making the whitespace match may undo what the test was trying to assert.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https:/github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https:/slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

_I have altered the test to match the behavior of the code. This seems to be inline with the intentions of the test (judging by the test name). No new functionality is included._

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https:/cla-assistant.io/slackhq/htmlsanitizer-hack).
