### PR TITLE
Add "missing" hhast config

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -13,3 +13,5 @@ hackfmt.tabs=true
 hackfmt.line_width=120
 hackfmt.add_trailing_commas=true
 user_attributes=
+allowed_decl_fixme_codes=2053,4047
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4047,4104,4107,4108,4110,4128,4135,4188,4240,4323

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"require": {
 		"hhvm/hhast": "^4.33.5",
 		"facebook/fbexpect": "^2.7.3",
-		"hhvm/hhvm-autoload": "^2.0",
+		"hhvm/hhvm-autoload": "^2.0|^3.0",
 		"hhvm/hacktest": "^2.0.0",
 		"hhvm/hsl": "^4.36.0",
 		"hhvm/hsl-experimental": "^4.37.3",

--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -1,0 +1,26 @@
+{
+  "roots": [ "src/", "tests/" ],
+  "builtinLinters": "all",
+  "overrides": [
+    {
+      "patterns": ["*"],
+      "disabledLinters": [
+        "Facebook\\HHAST\\PreferSingleQuotedStringLiteralLinter",
+        "Facebook\\HHAST\\NoPHPEqualityLinter",
+        "Facebook\\HHAST\\MustUseBracesForControlFlowLinter",
+        "Facebook\\HHAST\\MustUseOverrideAttributeLinter",
+        "Facebook\\HHAST\\NoStringInterpolationLinter",
+        "Facebook\\HHAST\\NoWhitespaceAtEndOfLineLinter",
+        "Facebook\\HHAST\\NoElseifLinter",
+        "Facebook\\HHAST\\NewlineAtEndOfFileLinter",
+        "Facebook\\HHAST\\UnusedParameterLinter",
+        "Facebook\\HHAST\\UnusedUseClauseLinter",
+        "Facebook\\HHAST\\GroupUseStatementsLinter",
+        "Facebook\\HHAST\\UnusedVariableLinter",
+        "Facebook\\HHAST\\CamelCasedMethodsUnderscoredFunctionsLinter",
+        "Facebook\\HHAST\\UseStatementWithoutKindLinter",
+        "Facebook\\HHAST\\GroupUseStatementAlphabetizationLinter"
+      ]
+    }
+  ]
+}

--- a/src/AttrDef/CSS/Number.hack
+++ b/src/AttrDef/CSS/Number.hack
@@ -42,6 +42,7 @@ class HTMLPurifier_AttrDef_CSS_Number extends HTMLPurifier\HTMLPurifier_AttrDef 
                 // FALLTHROUGH
             case '+':
                 $number = Str\slice($number, 1);
+            default: // Do nothing (required in newer hhvm versions)
         }
 
         if (\ctype_digit($number)) {


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

This project depends on hhast, but it does not have a config.
If the goal was to use hhast for its linters, you need this config.
I assume this is the goal, since there are no code references to hhast.
If you don't intend to call into hhast, it would be better suited as a dev dependency.
I have ignored all linters that did not lint clean.
I'd love to fix the lint errors for linters we decide to enable.

### Footnote

In order to lint with all the shiny new linters, I needed to base this branch on support_hhvm_4.71.
This commit 8c412d2 comes from that branch and may be ignored.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https:/github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https:/slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

_Test case: Code lints clean under the newest hhast and hhvm 4.71_

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https:/cla-assistant.io/slackhq/htmlsanitizer-hack).
