### PR TITLE
Bug report for confiscateAttr

### DIFF
--- a/tests/AttrTransformTest.hack
+++ b/tests/AttrTransformTest.hack
@@ -1,0 +1,55 @@
+namespace HTMLPurifier\_Private\Tests;
+
+use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTest;
+use type HTMLPurifier\HTMLPurifier_AttrTransform;
+use namespace HH\Lib\C;
+
+class AttrTransformTest extends HackTest {
+	private function instance(): InstantiatableAttrTransform {
+		return new InstantiatableAttrTransform();
+	}
+
+	public function testConfiscateAttrBug1(): void {
+		$obj = $this->instance();
+		$dict = dict['a' => 'b'];
+		$value = $obj->confiscateAttr(inout $dict, 'a');
+		// anti expect, this assertion should fail!
+		expect($value)->toEqual(null, 'Expected to get the value for the key "a", got null');
+
+		$dict = dict['a' => 'b'];
+		$value = $obj->confiscateAttrFixed(inout $dict, 'a');
+		expect($value)->toEqual('b');
+	}
+
+	public function testConfiscateAttrBug2(): void {
+		$obj = $this->instance();
+		$dict = dict['a' => 'b'];
+		// anti expect, this assertion should fail!
+		expect(() ==> $obj->confiscateAttr(inout $dict, 'b'))->toThrow(
+			\OutOfBoundsException::class,
+			'invalid index "b"',
+			'This exception should not be thrown',
+		);
+
+		$dict = dict['a' => 'b'];
+		$value = $obj->confiscateAttrFixed(inout $dict, 'b');
+		expect($value)->toEqual(null);
+	}
+}
+
+class InstantiatableAttrTransform extends HTMLPurifier_AttrTransform {
+	<<__Override>>
+	public function transform(mixed $s, mixed $t, mixed $ub): nothing {
+		invariant_violation('stub');
+	}
+	// Retrieves and removes an attribute.
+	public function confiscateAttrFixed<Tk as arraykey, Tv>(inout dict<Tk, Tv> $attr, Tk $key): ?Tv {
+		if (!C\contains_key($attr, $key)) {
+			return null;
+		}
+		$value = $attr[$key];
+		unset($attr[$key]);
+		return $value;
+	}
+}

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -1,4 +1,7 @@
 /* Created by Nikita Ashok and Jake Polacek on 08/04/2020 */
+
+namespace HTMLPurifier\_Private\Tests;
+
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\HackTest;
 use namespace HTMLPurifier;


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

There are no current callers of this method.
This method was misported.
The original used isset to check for the key's presence.
This implementation uses `C\contains` to check for the value's presence.

https://github.com/ezyang/htmlpurifier/blob/b81690c17eae5dbea7557d1f359af8dd17e9beef/library/HTMLPurifier/AttrTransform.php#L49-L57

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https:/github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https:/slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https:/cla-assistant.io/slackhq/htmlsanitizer-hack).
