### PR TITLE
Bugfix for fatal errors caused by the lacking preg hhi

### DIFF
--- a/tests/DOMLexTest.hack
+++ b/tests/DOMLexTest.hack
@@ -1,0 +1,13 @@
+namespace HTMLPurifier\_Private\Tests;
+
+use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTest;
+
+class DOMLexTest extends HackTest {
+    use ObjectCreationTrait;
+
+	public function testDOMLexBug1(): void {
+        // Unexpected TypeError
+        $this->makeDOMLex()->tokenizeHTML("<!--sometext-->", $this->makeConfig(), $this->makeContext());
+    }
+}

--- a/tests/LexerTest.hack
+++ b/tests/LexerTest.hack
@@ -1,0 +1,13 @@
+namespace HTMLPurifier\_Private\Tests;
+
+use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTest;
+
+final class LexerTest extends HackTest {
+    use ObjectCreationTrait;
+
+    public function testHTMLPurifierLexerBug1(): void {
+        // Unexpected TypeError
+        $this->makeLexer()->normalize('<![CDATA[sometext]]>', $this->makeConfig(), $this->makeContext());
+    }
+}

--- a/tests/ObjectCreationTrait.hack
+++ b/tests/ObjectCreationTrait.hack
@@ -1,0 +1,18 @@
+namespace HTMLPurifier\_Private\Tests;
+
+use type HTMLPurifier\{HTMLPurifier_Lexer, HTMLPurifier_Config, HTMLPurifier_ConfigSchema, HTMLPurifier_Context};
+
+trait ObjectCreationTrait {
+    private function makeLexer(): HTMLPurifier_Lexer {
+        return new HTMLPurifier_Lexer();
+    }
+    private function makeConfig(): HTMLPurifier_Config {
+        return new HTMLPurifier_Config($this->makeConfigSchema());
+    }
+    private function makeConfigSchema(): HTMLPurifier_ConfigSchema {
+        return new HTMLPurifier_ConfigSchema();
+    }
+    private function makeContext(): HTMLPurifier_Context {
+        return new HTMLPurifier_Context();
+    }
+}

--- a/tests/ObjectCreationTrait.hack
+++ b/tests/ObjectCreationTrait.hack
@@ -1,6 +1,7 @@
 namespace HTMLPurifier\_Private\Tests;
 
 use type HTMLPurifier\{HTMLPurifier_Lexer, HTMLPurifier_Config, HTMLPurifier_ConfigSchema, HTMLPurifier_Context};
+use type HTMLPurifier\Lexer\HTMLPurifier_Lexer_DOMLex;
 
 trait ObjectCreationTrait {
     private function makeLexer(): HTMLPurifier_Lexer {
@@ -14,5 +15,8 @@ trait ObjectCreationTrait {
     }
     private function makeContext(): HTMLPurifier_Context {
         return new HTMLPurifier_Context();
+    }
+    private function makeDOMLex(): HTMLPurifier_Lexer_DOMLex {
+        return new HTMLPurifier_Lexer_DOMLex();
     }
 }


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

preg_replace_callback take a callback, which is untyped.
The methods passed to them had a `vec<string>` typehint.
The actual type was array.
I've change the implementation to the well defined `Regex\replace_with()` api.
This was a reason to change the signature to the callbacks.
The methods are public, to it is a bc break in a strict sense.
However, these methods shouldn't be used outside of the class they are defined in.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https:/github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https:/slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https:/cla-assistant.io/slackhq/htmlsanitizer-hack).
