### PR TITLE
Make the constructor of HTMLPurifier_Encoder private

### DIFF
--- a/src/Encoder.hack
+++ b/src/Encoder.hack
@@ -20,14 +20,10 @@ class HTMLPurifier_Encoder {
      *  transcoding purposes */
     const int ICONV_UNUSABLE = 2;
 
-    /**
-    * Constructor throws fatal error if you attempt to instantiate class
-    */
-    public function __construct() {
-        \trigger_error('Cannot instantiate encoder, call methods statically');
-    }
+	<<__Deprecated('Cannot instantiate encoder, call methods statically')>>
+	final private function __construct() {}
 
-    /**
+	/**
     * Error-handler that mutes errors, alternative to shut-up operator
     * To be honest, I'm not sure when/if this is used
     */


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

The comment clearly intended calling the constructor to be a fatal error.
However, trigger_error defaults to E_USER_NOTICE (not fatal).
A better approach would be making the constructor private.
The __Deprecated attribute is merely for developer feedback.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https:/github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https:/slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

~* [] I've written tests to cover the new code and functionality included in this PR.~

_I can't write a test, since that would be a typechecker error._

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https:/cla-assistant.io/slackhq/htmlsanitizer-hack).
