### PR TITLE
Use fixed confiscate attr in AttrTransform

### DIFF
--- a/src/AttrTransform.hack
+++ b/src/AttrTransform.hack
@@ -21,12 +21,12 @@ abstract class HTMLPurifier_AttrTransform {
     }
 
     // Retrieves and removes an attribute.
-    public function confiscateAttr(inout dict<string, mixed> $attr, mixed $key): mixed {
-        if (!C\contains($attr, $key)) {
+    public function confiscateAttr<Tk as arraykey, Tv>(inout dict<Tk, Tv> $attr, Tk $key): ?Tv {
+        if (!C\contains_key($attr, $key)) {
             return null;
         }
-        $value = $attr[(string)$key];
-        unset($attr[(string)$key]);
+        $value = $attr[$key];
+        unset($attr[$key]);
         return $value;
     }
 }

--- a/tests/AttrTransformTest.hack
+++ b/tests/AttrTransformTest.hack
@@ -12,29 +12,20 @@ class AttrTransformTest extends HackTest {
 
 	public function testConfiscateAttrBug1(): void {
 		$obj = $this->instance();
-		$dict = dict['a' => 'b'];
-		$value = $obj->confiscateAttr(inout $dict, 'a');
-		// anti expect, this assertion should fail!
-		expect($value)->toEqual(null, 'Expected to get the value for the key "a", got null');
 
 		$dict = dict['a' => 'b'];
-		$value = $obj->confiscateAttrFixed(inout $dict, 'a');
+		$value = $obj->confiscateAttr(inout $dict, 'a');
 		expect($value)->toEqual('b');
+		expect($dict)->toEqual(dict[]);
 	}
 
 	public function testConfiscateAttrBug2(): void {
 		$obj = $this->instance();
-		$dict = dict['a' => 'b'];
-		// anti expect, this assertion should fail!
-		expect(() ==> $obj->confiscateAttr(inout $dict, 'b'))->toThrow(
-			\OutOfBoundsException::class,
-			'invalid index "b"',
-			'This exception should not be thrown',
-		);
 
 		$dict = dict['a' => 'b'];
-		$value = $obj->confiscateAttrFixed(inout $dict, 'b');
+		$value = $obj->confiscateAttr(inout $dict, 'b');
 		expect($value)->toEqual(null);
+		expect($dict)->toEqual(dict['a' => 'b']);
 	}
 }
 
@@ -42,14 +33,5 @@ class InstantiatableAttrTransform extends HTMLPurifier_AttrTransform {
 	<<__Override>>
 	public function transform(mixed $s, mixed $t, mixed $ub): nothing {
 		invariant_violation('stub');
-	}
-	// Retrieves and removes an attribute.
-	public function confiscateAttrFixed<Tk as arraykey, Tv>(inout dict<Tk, Tv> $attr, Tk $key): ?Tv {
-		if (!C\contains_key($attr, $key)) {
-			return null;
-		}
-		$value = $attr[$key];
-		unset($attr[$key]);
-		return $value;
 	}
 }


### PR DESCRIPTION
###  Summary

The PR which demonstrated the incorrect behavior has been accepted.
[oss repo PR 6](https://github.com/slackhq/htmlsanitizer-hack/pull/6)
This applies those changes and changes the signature of confiscateAttr.
Anti assertions have been removed.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
