### PR TITLE
complete the implementation of cleanUTF8

### DIFF
--- a/src/Encoder.hack
+++ b/src/Encoder.hack
@@ -20,10 +20,10 @@ class HTMLPurifier_Encoder {
      *  transcoding purposes */
     const int ICONV_UNUSABLE = 2;
 
-	<<__Deprecated('Cannot instantiate encoder, call methods statically')>>
-	final private function __construct() {}
+    <<__Deprecated('Cannot instantiate encoder, call methods statically')>>
+    final private function __construct() {}
 
-	/**
+    /**
     * Error-handler that mutes errors, alternative to shut-up operator
     * To be honest, I'm not sure when/if this is used
     */
@@ -117,149 +117,149 @@ class HTMLPurifier_Encoder {
             return $str;
         }
 
-		$mState = 0; // cached expected number of octets after the current octet
-		// until the beginning of the next UTF8 character sequence
-		$mUcs4 = 0; // cached Unicode character
-		$mBytes = 1; // cached expected number of octets in the current sequence
+        $mState = 0; // cached expected number of octets after the current octet
+        // until the beginning of the next UTF8 character sequence
+        $mUcs4 = 0; // cached Unicode character
+        $mBytes = 1; // cached expected number of octets in the current sequence
 
-		// original code involved an $out that was an array of Unicode
-		// codepoints.  Instead of having to convert back into UTF-8, we've
-		// decided to directly append valid UTF-8 characters onto a string
-		// $out once they're done.  $char accumulates raw bytes, while $mUcs4
-		// turns into the Unicode code point, so there's some redundancy.
+        // original code involved an $out that was an array of Unicode
+        // codepoints.  Instead of having to convert back into UTF-8, we've
+        // decided to directly append valid UTF-8 characters onto a string
+        // $out once they're done.  $char accumulates raw bytes, while $mUcs4
+        // turns into the Unicode code point, so there's some redundancy.
 
-		$out = '';
-		$char = '';
+        $out = '';
+        $char = '';
 
-		$len = Str\length($str);
-		for ($i = 0; $i < $len; $i++) {
-			$in = \ord($str[$i]);
-			$char .= $str[$i]; // append byte to char
-			if (0 == $mState) {
-				// When mState is zero we expect either a US-ASCII character
-				// or a multi-octet sequence.
-				if (0 == (0x80 & ($in))) {
-					// US-ASCII, pass straight through.
-					if (
-						($in <= 31 || $in == 127) && !($in == 9 || $in == 13 || $in == 10) // save \r\t\n
-					) {
-						// control characters, remove
-					} else {
-						$out .= $char;
-					}
-					// reset
-					$char = '';
-					$mBytes = 1;
-				} elseif (0xC0 == (0xE0 & ($in))) {
-					// First octet of 2 octet sequence
-					$mUcs4 = ($in);
-					$mUcs4 = ($mUcs4 & 0x1F) << 6;
-					$mState = 1;
-					$mBytes = 2;
-				} elseif (0xE0 == (0xF0 & ($in))) {
-					// First octet of 3 octet sequence
-					$mUcs4 = ($in);
-					$mUcs4 = ($mUcs4 & 0x0F) << 12;
-					$mState = 2;
-					$mBytes = 3;
-				} elseif (0xF0 == (0xF8 & ($in))) {
-					// First octet of 4 octet sequence
-					$mUcs4 = ($in);
-					$mUcs4 = ($mUcs4 & 0x07) << 18;
-					$mState = 3;
-					$mBytes = 4;
-				} elseif (0xF8 == (0xFC & ($in))) {
-					// First octet of 5 octet sequence.
-					//
-					// This is illegal because the encoded codepoint must be
-					// either:
-					// (a) not the shortest form or
-					// (b) outside the Unicode range of 0-0x10FFFF.
-					// Rather than trying to resynchronize, we will carry on
-					// until the end of the sequence and let the later error
-					// handling code catch it.
-					$mUcs4 = ($in);
-					$mUcs4 = ($mUcs4 & 0x03) << 24;
-					$mState = 4;
-					$mBytes = 5;
-				} elseif (0xFC == (0xFE & ($in))) {
-					// First octet of 6 octet sequence, see comments for 5
-					// octet sequence.
-					$mUcs4 = ($in);
-					$mUcs4 = ($mUcs4 & 1) << 30;
-					$mState = 5;
-					$mBytes = 6;
-				} else {
-					// Current octet is neither in the US-ASCII range nor a
-					// legal first octet of a multi-octet sequence.
-					$mState = 0;
-					$mUcs4 = 0;
-					$mBytes = 1;
-					$char = '';
-				}
-			} else {
-				// When mState is non-zero, we expect a continuation of the
-				// multi-octet sequence
-				if (0x80 == (0xC0 & ($in))) {
-					// Legal continuation.
-					$shift = ($mState - 1) * 6;
-					$tmp = $in;
-					$tmp = ($tmp & 0x0000003F) << $shift;
-					$mUcs4 |= $tmp;
-					--$mState;
-					if (0 == $mState) {
-						// End of the multi-octet sequence. mUcs4 now contains
-						// the final Unicode codepoint to be output
+        $len = Str\length($str);
+        for ($i = 0; $i < $len; $i++) {
+            $in = \ord($str[$i]);
+            $char .= $str[$i]; // append byte to char
+            if (0 == $mState) {
+                // When mState is zero we expect either a US-ASCII character
+                // or a multi-octet sequence.
+                if (0 == (0x80 & ($in))) {
+                    // US-ASCII, pass straight through.
+                    if (
+                        ($in <= 31 || $in == 127) && !($in == 9 || $in == 13 || $in == 10) // save \r\t\n
+                    ) {
+                        // control characters, remove
+                    } else {
+                        $out .= $char;
+                    }
+                    // reset
+                    $char = '';
+                    $mBytes = 1;
+                } elseif (0xC0 == (0xE0 & ($in))) {
+                    // First octet of 2 octet sequence
+                    $mUcs4 = ($in);
+                    $mUcs4 = ($mUcs4 & 0x1F) << 6;
+                    $mState = 1;
+                    $mBytes = 2;
+                } elseif (0xE0 == (0xF0 & ($in))) {
+                    // First octet of 3 octet sequence
+                    $mUcs4 = ($in);
+                    $mUcs4 = ($mUcs4 & 0x0F) << 12;
+                    $mState = 2;
+                    $mBytes = 3;
+                } elseif (0xF0 == (0xF8 & ($in))) {
+                    // First octet of 4 octet sequence
+                    $mUcs4 = ($in);
+                    $mUcs4 = ($mUcs4 & 0x07) << 18;
+                    $mState = 3;
+                    $mBytes = 4;
+                } elseif (0xF8 == (0xFC & ($in))) {
+                    // First octet of 5 octet sequence.
+                    //
+                    // This is illegal because the encoded codepoint must be
+                    // either:
+                    // (a) not the shortest form or
+                    // (b) outside the Unicode range of 0-0x10FFFF.
+                    // Rather than trying to resynchronize, we will carry on
+                    // until the end of the sequence and let the later error
+                    // handling code catch it.
+                    $mUcs4 = ($in);
+                    $mUcs4 = ($mUcs4 & 0x03) << 24;
+                    $mState = 4;
+                    $mBytes = 5;
+                } elseif (0xFC == (0xFE & ($in))) {
+                    // First octet of 6 octet sequence, see comments for 5
+                    // octet sequence.
+                    $mUcs4 = ($in);
+                    $mUcs4 = ($mUcs4 & 1) << 30;
+                    $mState = 5;
+                    $mBytes = 6;
+                } else {
+                    // Current octet is neither in the US-ASCII range nor a
+                    // legal first octet of a multi-octet sequence.
+                    $mState = 0;
+                    $mUcs4 = 0;
+                    $mBytes = 1;
+                    $char = '';
+                }
+            } else {
+                // When mState is non-zero, we expect a continuation of the
+                // multi-octet sequence
+                if (0x80 == (0xC0 & ($in))) {
+                    // Legal continuation.
+                    $shift = ($mState - 1) * 6;
+                    $tmp = $in;
+                    $tmp = ($tmp & 0x0000003F) << $shift;
+                    $mUcs4 |= $tmp;
+                    --$mState;
+                    if (0 == $mState) {
+                        // End of the multi-octet sequence. mUcs4 now contains
+                        // the final Unicode codepoint to be output
 
-						// Check for illegal sequences and codepoints.
+                        // Check for illegal sequences and codepoints.
 
-						// From Unicode 3.1, non-shortest form is illegal
-						if (
-							((2 == $mBytes) && ($mUcs4 < 0x0080)) ||
-							((3 == $mBytes) && ($mUcs4 < 0x0800)) ||
-							((4 == $mBytes) && ($mUcs4 < 0x10000)) ||
-							(4 < $mBytes) ||
-							// From Unicode 3.2, surrogate characters = illegal
-							(($mUcs4 & 0xFFFFF800) == 0xD800) ||
-							// Codepoints outside the Unicode range are illegal
-							($mUcs4 > 0x10FFFF)
-						) {
+                        // From Unicode 3.1, non-shortest form is illegal
+                        if (
+                            ((2 == $mBytes) && ($mUcs4 < 0x0080)) ||
+                            ((3 == $mBytes) && ($mUcs4 < 0x0800)) ||
+                            ((4 == $mBytes) && ($mUcs4 < 0x10000)) ||
+                            (4 < $mBytes) ||
+                            // From Unicode 3.2, surrogate characters = illegal
+                            (($mUcs4 & 0xFFFFF800) == 0xD800) ||
+                            // Codepoints outside the Unicode range are illegal
+                            ($mUcs4 > 0x10FFFF)
+                        ) {
 
-						} elseif (
-							0xFEFF != $mUcs4 && // omit BOM
-							// check for valid Char unicode codepoints
-							(
-								0x9 == $mUcs4 ||
-								0xA == $mUcs4 ||
-								0xD == $mUcs4 ||
-								(0x20 <= $mUcs4 && 0x7E >= $mUcs4) ||
-								// 7F-9F is not strictly prohibited by XML,
-								// but it is non-SGML, and thus we don't allow it
-								(0xA0 <= $mUcs4 && 0xD7FF >= $mUcs4) ||
-								(0xE000 <= $mUcs4 && 0xFFFD >= $mUcs4) ||
-								(0x10000 <= $mUcs4 && 0x10FFFF >= $mUcs4)
-							)
-						) {
-							$out .= $char;
-						}
-						// initialize UTF8 cache (reset)
-						$mState = 0;
-						$mUcs4 = 0;
-						$mBytes = 1;
-						$char = '';
-					}
-				} else {
-					// ((0xC0 & (*in) != 0x80) && (mState != 0))
-					// Incomplete multi-octet sequence.
-					// used to result in complete fail, but we'll reset
-					$mState = 0;
-					$mUcs4 = 0;
-					$mBytes = 1;
-					$char = '';
-				}
-			}
-		}
-		return $out;
+                        } elseif (
+                            0xFEFF != $mUcs4 && // omit BOM
+                            // check for valid Char unicode codepoints
+                            (
+                                0x9 == $mUcs4 ||
+                                0xA == $mUcs4 ||
+                                0xD == $mUcs4 ||
+                                (0x20 <= $mUcs4 && 0x7E >= $mUcs4) ||
+                                // 7F-9F is not strictly prohibited by XML,
+                                // but it is non-SGML, and thus we don't allow it
+                                (0xA0 <= $mUcs4 && 0xD7FF >= $mUcs4) ||
+                                (0xE000 <= $mUcs4 && 0xFFFD >= $mUcs4) ||
+                                (0x10000 <= $mUcs4 && 0x10FFFF >= $mUcs4)
+                            )
+                        ) {
+                            $out .= $char;
+                        }
+                        // initialize UTF8 cache (reset)
+                        $mState = 0;
+                        $mUcs4 = 0;
+                        $mBytes = 1;
+                        $char = '';
+                    }
+                } else {
+                    // ((0xC0 & (*in) != 0x80) && (mState != 0))
+                    // Incomplete multi-octet sequence.
+                    // used to result in complete fail, but we'll reset
+                    $mState = 0;
+                    $mUcs4 = 0;
+                    $mBytes = 1;
+                    $char = '';
+                }
+            }
+        }
+        return $out;
     }
 
     /**

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -320,4 +320,120 @@ class HTMLPurifierTest extends HackTest {
         expect(true)->toNotBeNull();
 		echo "finished.\n\n";
     }
+
+	public function testSpecialCharacterValidateUTF8() : void {
+		echo "\nrunning testWebappPolicy()...";
+        $policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
+            'b' => vec[],
+            'ul'=> vec[],
+            'li' => vec[],
+            'ol' => vec[],
+            'h2' => vec[],
+            'h4' => vec[],
+            'br' => vec[],
+            'div' => vec[],
+            'strong' => vec[],
+            'del' => vec[],
+            'em' => vec[],
+            'pre' => vec[],
+            'code' => vec[],
+            'table' => vec[],
+            'tbody' => vec[],
+            'td' => vec[],
+            'th' => vec[],
+            'thead' => vec[],
+            'tr' => vec[],
+            'a' => vec['id', 'name', 'href', 'target', 'rel'],
+            'h3' => vec['class'],
+            'p' => vec['class'],
+            'aside' => vec['class'],
+            'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes']
+            ]
+        );
+        $config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+        $purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<h2>Guest accounts and shared channels</h2>
+<h3>Guest accounts</h3>
+<p>These are great for working with someone who feels like a member of your organization but needs only limited access to Slack.</p>
+<p><strong>It’s important to note that guest accounts:</strong></p>
+<ul>
+<li>Are available for paid workspaces. Guests can belong to a single channel or multiple channels.</li>
+<li>Can be invited to your workspace just like regular members via the invitations page.</li>
+<li>Have icons by their profile photos: a triangle for single-channel guests and a square for multi-channel guests.</li>
+</ul>
+<h3>Shared channels</h3>
+<p>Two separate organizations can work together in Slack, each from within their own Slack workspace.</p>
+<p><strong>The benefits of shared channels include:</strong></p>
+<ul>
+<li>Working with external parties is as straightforward and fluid as working with your own colleagues. </li>
+<li>Both teams have a common place to collaborate, loop in the right people on an as-needed basis, and build a collective repository of knowledge that anyone on either team can add to and reference.</li>
+<li>Both teams can send messages, share files, and access the channel history.</li>
+<li>Any member of the shared channel can also direct-message (DM) any other member in the channel, even if they’re from the other team.</li>
+</ul>
+<h2>Should I create a guest account or use a shared channel?</h2>
+<p><strong>If you’re working with&#8230;</strong></p>
+<ul>
+<li>An individual &#8211; Then use a guest account</li>
+<li>A team &#8211; Then use a shared channel</li>
+</ul>
+<p>More and more organizations are moving toward shared channels for the additional control and flexibility they provide—especially when collaborating with two or more people at another company.</p>
+<h2>Guests vs. shared channels comparison</h2>
+[aside headline="Who are you working with?" description="" bullets="Guests: Someone who feels like a member of your organization but needs limited access to Slack, such as contractors and interns | Shared channels: An external organization, like clients, vendors and partners. Both organizations need to be on a paid Slack plan. " /]
+<p>&nbsp;</p>
+[aside headline="How many people are involved?" description="" bullets="Guests: Only one or two people from the guest organization | Shared channels: Multiple people from each company are involved, with the ability to add members as work scales" /]
+<p>&nbsp;</p>
+[aside headline="Data access" description="" bullets="Guests: Only the host organization has access to the communication and files when the guest account expires | Shared channels: Each company keeps a record of the communication and files after the channel is disconnected" /]
+<p>&nbsp;</p>
+[aside headline="Security" description="" bullets="Guests: Only workspace admins or owners can invite or manage guest accounts | Shared channels: Users can initiate a shared channel by sharing an invitation link with their external partner. Depending on your settings, admins on both sides must approve the shared channel and can disconnect the shared channel at any time" /]
+<p>&nbsp;</p>
+[aside headline="Cost" description="" bullets="Guests: Teams get 5 free single-channel guests per paid active member, and multi-channel guests are billed as regular users | Shared channels: Unlimited number of shared channels at no cost" /]
+<p>&nbsp;</p>
+[aside headline="Ease of access" description="" bullets="Guests: Guests need to log into your organization&rsquo;s workspace, rather than using their own Slack workspace | Shared channels: People from other companies can collaborate in the shared channel right away from their own Slack workspace" /]
+<p>&nbsp;</p>
+[aside headline="Custom emoji" description="" bullets="Guests: Guests will have access to your full library of emoji | Shared channels: Custom emoji can be used and will be displayed to both teams. The other team can +1 a custom emoji of yours but can&rsquo;t see your set in their emoji picker" /]
+<p>&nbsp;</p>
+[aside headline="Direct messages" description="" bullets="Guests: Guests can DM only members of the channel(s) that they&rsquo;re in | Shared channels: You can DM or group DM anyone in a shared channel, including external members" /]
+<p>&nbsp;</p>
+[aside headline="Invites / admin management" description="" bullets="Guests: Admins must manually provision guest accounts one by one. Admins can choose an automatic expiration date for each guest account  | Shared channels: Once the shared channel is created, both teams can invite others from their workspace to join the channel as projects evolve and additional people need access" /]';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html = '<h2>Guest accounts and shared channels</h2>
+<h3>Guest accounts</h3>
+<p>These are great for working with someone who feels like a member of your organization but needs only limited access to Slack.</p>
+<p><strong>It’s important to note that guest accounts:</strong></p>
+<ul><li>Are available for paid workspaces. Guests can belong to a single channel or multiple channels.</li>
+<li>Can be invited to your workspace just like regular members via the invitations page.</li>
+<li>Have icons by their profile photos: a triangle for single-channel guests and a square for multi-channel guests.</li>
+</ul><h3>Shared channels</h3>
+<p>Two separate organizations can work together in Slack, each from within their own Slack workspace.</p>
+<p><strong>The benefits of shared channels include:</strong></p>
+<ul><li>Working with external parties is as straightforward and fluid as working with your own colleagues. </li>
+<li>Both teams have a common place to collaborate, loop in the right people on an as-needed basis, and build a collective repository of knowledge that anyone on either team can add to and reference.</li>
+<li>Both teams can send messages, share files, and access the channel history.</li>
+<li>Any member of the shared channel can also direct-message (DM) any other member in the channel, even if they’re from the other team.</li>
+</ul><h2>Should I create a guest account or use a shared channel?</h2>
+<p><strong>If you’re working with…</strong></p>
+<ul><li>An individual – Then use a guest account</li>
+<li>A team – Then use a shared channel</li>
+</ul><p>More and more organizations are moving toward shared channels for the additional control and flexibility they provide—especially when collaborating with two or more people at another company.</p>
+<h2>Guests vs. shared channels comparison</h2>
+[aside headline="Who are you working with?" description="" bullets="Guests: Someone who feels like a member of your organization but needs limited access to Slack, such as contractors and interns | Shared channels: An external organization, like clients, vendors and partners. Both organizations need to be on a paid Slack plan. " /]
+<p> </p>
+[aside headline="How many people are involved?" description="" bullets="Guests: Only one or two people from the guest organization | Shared channels: Multiple people from each company are involved, with the ability to add members as work scales" /]
+<p> </p>
+[aside headline="Data access" description="" bullets="Guests: Only the host organization has access to the communication and files when the guest account expires | Shared channels: Each company keeps a record of the communication and files after the channel is disconnected" /]
+<p> </p>
+[aside headline="Security" description="" bullets="Guests: Only workspace admins or owners can invite or manage guest accounts | Shared channels: Users can initiate a shared channel by sharing an invitation link with their external partner. Depending on your settings, admins on both sides must approve the shared channel and can disconnect the shared channel at any time" /]
+<p> </p>
+[aside headline="Cost" description="" bullets="Guests: Teams get 5 free single-channel guests per paid active member, and multi-channel guests are billed as regular users | Shared channels: Unlimited number of shared channels at no cost" /]
+<p> </p>
+[aside headline="Ease of access" description="" bullets="Guests: Guests need to log into your organization’s workspace, rather than using their own Slack workspace | Shared channels: People from other companies can collaborate in the shared channel right away from their own Slack workspace" /]
+<p> </p>
+[aside headline="Custom emoji" description="" bullets="Guests: Guests will have access to your full library of emoji | Shared channels: Custom emoji can be used and will be displayed to both teams. The other team can +1 a custom emoji of yours but can’t see your set in their emoji picker" /]
+<p> </p>
+[aside headline="Direct messages" description="" bullets="Guests: Guests can DM only members of the channel(s) that they’re in | Shared channels: You can DM or group DM anyone in a shared channel, including external members" /]
+<p> </p>
+[aside headline="Invites / admin management" description="" bullets="Guests: Admins must manually provision guest accounts one by one. Admins can choose an automatic expiration date for each guest account  | Shared channels: Once the shared channel is created, both teams can invite others from their workspace to join the channel as projects evolve and additional people need access" /]';
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+    }
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -103,19 +103,12 @@ class HTMLPurifierTest extends HackTest {
 </table>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<table>
-  <caption>
+		expect($clean_html)->toEqual('<table><caption>
     Cool table
   </caption>
-  <tfoot>
-    <tr>
-      <th>I can do so much!</th>
-    </tr>
-  </tfoot>
-  <tbody><tr>
-    <td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
-  </tr>
-</tbody></table>');
+  <tfoot><tr><th>I can do so much!</th>
+    </tr></tfoot><tbody><tr><td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
+  </tr></tbody></table>');
 	}
 
 	public function testDOM() : void {
@@ -327,55 +320,4 @@ class HTMLPurifierTest extends HackTest {
         expect(true)->toNotBeNull();
 		echo "finished.\n\n";
     }
-
-	public function testWebappInput(): void {
-		echo "\nrunning testWebappPolicy()...";
-		$policy = new HTMLPurifier\HTMLPurifier_Policy(
-			dict[
-				'b' => vec[],
-				'ul' => vec[],
-				'li' => vec[],
-				'ol' => vec[],
-				'h2' => vec[],
-				'h4' => vec[],
-				'br' => vec[],
-				'div' => vec[],
-				'strong' => vec[],
-				'del' => vec[],
-				'em' => vec[],
-				'pre' => vec[],
-				'code' => vec[],
-				'table' => vec[],
-				'tbody' => vec[],
-				'td' => vec[],
-				'th' => vec[],
-				'thead' => vec[],
-				'tr' => vec[],
-				'a' => vec['id', 'name', 'href', 'target', 'rel'],
-				'h3' => vec['class'],
-				'p' => vec['class'],
-				'aside' => vec['class'],
-				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
-			],
-		);
-		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
-		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
-		$dirty_html = '<ul>
-<li>Working with external parties is as straightforward and fluid as working with your own colleagues. </li>
-<li>Both teams have a common place to collaborate, loop in the right people on an as-needed basis, and build a collective repository of knowledge that anyone on either team can add to and reference.</li>
-<li>Both teams can send messages, share files, and access the channel history.</li>
-<li>Any member of the shared channel can also direct-message (DM) any other member in the channel, even if they’re from the other team.</li>
-</ul>';
-
-		$expected_html = '<ul>
-<li>Working with external parties is as straightforward and fluid as working with your own colleagues. </li>
-<li>Both teams have a common place to collaborate, loop in the right people on an as-needed basis, and build a collective repository of knowledge that anyone on either team can add to and reference.</li>
-<li>Both teams can send messages, share files, and access the channel history.</li>
-<li>Any member of the shared channel can also direct-message (DM) any other member in the channel, even if they’re from the other team.</li>
-</ul>';
-
-		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual($expected_html);
-		echo "finished.\n\n";
-	}
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -352,87 +352,45 @@ class HTMLPurifierTest extends HackTest {
 		);
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
-		$dirty_html = '<h2>Guest accounts and shared channels</h2>
-<h3>Guest accounts</h3>
-<p>These are great for working with someone who feels like a member of your organization but needs only limited access to Slack.</p>
-<p><strong>It’s important to note that guest accounts:</strong></p>
-<ul>
-<li>Are available for paid workspaces. Guests can belong to a single channel or multiple channels.</li>
-<li>Can be invited to your workspace just like regular members via the invitations page.</li>
-<li>Have icons by their profile photos: a triangle for single-channel guests and a square for multi-channel guests.</li>
+		$dirty_html = '<ul>
+<li>Just a sentence. </li>
+<li>Just a sentence.</li>
+<li>Just a sentence.</li>
+<li>Just a sentence.</li>
 </ul>
-<h3>Shared channels</h3>
-<p>Two separate organizations can work together in Slack, each from within their own Slack workspace.</p>
-<p><strong>The benefits of shared channels include:</strong></p>
-<ul>
-<li>Working with external parties is as straightforward and fluid as working with your own colleagues. </li>
-<li>Both teams have a common place to collaborate, loop in the right people on an as-needed basis, and build a collective repository of knowledge that anyone on either team can add to and reference.</li>
-<li>Both teams can send messages, share files, and access the channel history.</li>
-<li>Any member of the shared channel can also direct-message (DM) any other member in the channel, even if they’re from the other team.</li>
-</ul>
-<h2>Should I create a guest account or use a shared channel?</h2>
+<h2>Should I?</h2>
 <p><strong>If you’re working with&#8230;</strong></p>
 <ul>
-<li>An individual &#8211; Then use a guest account</li>
-<li>A team &#8211; Then use a shared channel</li>
+<li>An individual &#8211; abc</li>
+<li>A team &#8211; abc</li>
 </ul>
-<p>More and more organizations are moving toward shared channels for the additional control and flexibility they provide—especially when collaborating with two or more people at another company.</p>
-<h2>Guests vs. shared channels comparison</h2>
-[aside headline="Who are you working with?" description="" bullets="Guests: Someone who feels like a member of your organization but needs limited access to Slack, such as contractors and interns | Shared channels: An external organization, like clients, vendors and partners. Both organizations need to be on a paid Slack plan. " /]
+<p>p tags.</p>
+<h2>header 2</h2>
+[aside headline="Who are you working with?" description="" bullets="a sentence. " /]
 <p>&nbsp;</p>
-[aside headline="How many people are involved?" description="" bullets="Guests: Only one or two people from the guest organization | Shared channels: Multiple people from each company are involved, with the ability to add members as work scales" /]
+[aside headline="How many people are involved?" description="" bullets="a sentence" /]
 <p>&nbsp;</p>
-[aside headline="Data access" description="" bullets="Guests: Only the host organization has access to the communication and files when the guest account expires | Shared channels: Each company keeps a record of the communication and files after the channel is disconnected" /]
+[aside headline="Data access" description="" bullets="a sentence" /]
 <p>&nbsp;</p>
-[aside headline="Security" description="" bullets="Guests: Only workspace admins or owners can invite or manage guest accounts | Shared channels: Users can initiate a shared channel by sharing an invitation link with their external partner. Depending on your settings, admins on both sides must approve the shared channel and can disconnect the shared channel at any time" /]
-<p>&nbsp;</p>
-[aside headline="Cost" description="" bullets="Guests: Teams get 5 free single-channel guests per paid active member, and multi-channel guests are billed as regular users | Shared channels: Unlimited number of shared channels at no cost" /]
-<p>&nbsp;</p>
-[aside headline="Ease of access" description="" bullets="Guests: Guests need to log into your organization&rsquo;s workspace, rather than using their own Slack workspace | Shared channels: People from other companies can collaborate in the shared channel right away from their own Slack workspace" /]
-<p>&nbsp;</p>
-[aside headline="Custom emoji" description="" bullets="Guests: Guests will have access to your full library of emoji | Shared channels: Custom emoji can be used and will be displayed to both teams. The other team can +1 a custom emoji of yours but can&rsquo;t see your set in their emoji picker" /]
-<p>&nbsp;</p>
-[aside headline="Direct messages" description="" bullets="Guests: Guests can DM only members of the channel(s) that they&rsquo;re in | Shared channels: You can DM or group DM anyone in a shared channel, including external members" /]
-<p>&nbsp;</p>
-[aside headline="Invites / admin management" description="" bullets="Guests: Admins must manually provision guest accounts one by one. Admins can choose an automatic expiration date for each guest account  | Shared channels: Once the shared channel is created, both teams can invite others from their workspace to join the channel as projects evolve and additional people need access" /]';
+[aside headline="Security" description="" bullets="a sentence" /]';
 		$clean_html = $purifier->purify($dirty_html);
-		$expected_html = '<h2>Guest accounts and shared channels</h2>
-<h3>Guest accounts</h3>
-<p>These are great for working with someone who feels like a member of your organization but needs only limited access to Slack.</p>
-<p><strong>It’s important to note that guest accounts:</strong></p>
-<ul><li>Are available for paid workspaces. Guests can belong to a single channel or multiple channels.</li>
-<li>Can be invited to your workspace just like regular members via the invitations page.</li>
-<li>Have icons by their profile photos: a triangle for single-channel guests and a square for multi-channel guests.</li>
-</ul><h3>Shared channels</h3>
-<p>Two separate organizations can work together in Slack, each from within their own Slack workspace.</p>
-<p><strong>The benefits of shared channels include:</strong></p>
-<ul><li>Working with external parties is as straightforward and fluid as working with your own colleagues. </li>
-<li>Both teams have a common place to collaborate, loop in the right people on an as-needed basis, and build a collective repository of knowledge that anyone on either team can add to and reference.</li>
-<li>Both teams can send messages, share files, and access the channel history.</li>
-<li>Any member of the shared channel can also direct-message (DM) any other member in the channel, even if they’re from the other team.</li>
-</ul><h2>Should I create a guest account or use a shared channel?</h2>
+		$expected_html = '<ul><li>Just a sentence. </li>
+<li>Just a sentence.</li>
+<li>Just a sentence.</li>
+<li>Just a sentence.</li>
+</ul><h2>Should I?</h2>
 <p><strong>If you’re working with…</strong></p>
-<ul><li>An individual – Then use a guest account</li>
-<li>A team – Then use a shared channel</li>
-</ul><p>More and more organizations are moving toward shared channels for the additional control and flexibility they provide—especially when collaborating with two or more people at another company.</p>
-<h2>Guests vs. shared channels comparison</h2>
-[aside headline="Who are you working with?" description="" bullets="Guests: Someone who feels like a member of your organization but needs limited access to Slack, such as contractors and interns | Shared channels: An external organization, like clients, vendors and partners. Both organizations need to be on a paid Slack plan. " /]
+<ul><li>An individual – abc</li>
+<li>A team – abc</li>
+</ul><p>p tags.</p>
+<h2>header 2</h2>
+[aside headline="Who are you working with?" description="" bullets="a sentence. " /]
 <p> </p>
-[aside headline="How many people are involved?" description="" bullets="Guests: Only one or two people from the guest organization | Shared channels: Multiple people from each company are involved, with the ability to add members as work scales" /]
+[aside headline="How many people are involved?" description="" bullets="a sentence" /]
 <p> </p>
-[aside headline="Data access" description="" bullets="Guests: Only the host organization has access to the communication and files when the guest account expires | Shared channels: Each company keeps a record of the communication and files after the channel is disconnected" /]
+[aside headline="Data access" description="" bullets="a sentence" /]
 <p> </p>
-[aside headline="Security" description="" bullets="Guests: Only workspace admins or owners can invite or manage guest accounts | Shared channels: Users can initiate a shared channel by sharing an invitation link with their external partner. Depending on your settings, admins on both sides must approve the shared channel and can disconnect the shared channel at any time" /]
-<p> </p>
-[aside headline="Cost" description="" bullets="Guests: Teams get 5 free single-channel guests per paid active member, and multi-channel guests are billed as regular users | Shared channels: Unlimited number of shared channels at no cost" /]
-<p> </p>
-[aside headline="Ease of access" description="" bullets="Guests: Guests need to log into your organization’s workspace, rather than using their own Slack workspace | Shared channels: People from other companies can collaborate in the shared channel right away from their own Slack workspace" /]
-<p> </p>
-[aside headline="Custom emoji" description="" bullets="Guests: Guests will have access to your full library of emoji | Shared channels: Custom emoji can be used and will be displayed to both teams. The other team can +1 a custom emoji of yours but can’t see your set in their emoji picker" /]
-<p> </p>
-[aside headline="Direct messages" description="" bullets="Guests: Guests can DM only members of the channel(s) that they’re in | Shared channels: You can DM or group DM anyone in a shared channel, including external members" /]
-<p> </p>
-[aside headline="Invites / admin management" description="" bullets="Guests: Admins must manually provision guest accounts one by one. Admins can choose an automatic expiration date for each guest account  | Shared channels: Once the shared channel is created, both teams can invite others from their workspace to join the channel as projects evolve and additional people need access" /]';
+[aside headline="Security" description="" bullets="a sentence" /]';
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -88,26 +88,26 @@ class HTMLPurifierTest extends HackTest {
 
 		$dirty_html = '<table>
   <caption>
-    Cool table
+	Cool table
   </caption>
   <tfoot>
-    <tr>
-      <th>I can do so much!</th>
-    </tr>
+	<tr>
+	  <th>I can do so much!</th>
+	</tr>
   </tfoot>
   <tr>
-    <td style="font-size:16pt;
-      color:#F00;font-family:sans-serif;
-      text-align:center;">Wow</td>
+	<td style="font-size:16pt;
+	  color:#F00;font-family:sans-serif;
+	  text-align:center;">Wow</td>
   </tr>
 </table>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
 		expect($clean_html)->toEqual('<table><caption>
-    Cool table
+	Cool table
   </caption>
   <tfoot><tr><th>I can do so much!</th>
-    </tr></tfoot><tbody><tr><td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
+	</tr></tfoot><tbody><tr><td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
   </tr></tbody></table>');
 	}
 
@@ -237,24 +237,24 @@ class HTMLPurifierTest extends HackTest {
   		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict["iframe"=>vec["title","width","height","src","allowfullscreen"]]);
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
 
-        // Test1 clean iframe with usertesting domain with no protocol
-        $dirty_html = '<iframe
-            title="Wildlife"
-            width="500"
-            height="400"
-            src="//www.example.com"
-            allowfullscreen=true
-            ></iframe>';
+		// Test1 clean iframe with usertesting domain with no protocol
+		$dirty_html = '<iframe
+			title="Wildlife"
+			width="500"
+			height="400"
+			src="//www.example.com"
+			allowfullscreen=true
+			></iframe>';
 		$clean_html = $purifier->purify($dirty_html);
 		expect($clean_html)->toEqual('<iframe title="Wildlife" width="500" height="400" src="//www.example.com" allowfullscreen="true"></iframe>');
 
-        $dirty_html = '<iframe
-            title="Wildlife"
-            width="500"
-            height="400"
-            src="https://www.example.com/"
-            allowfullscreen=true
-            ></iframe>';		
+		$dirty_html = '<iframe
+			title="Wildlife"
+			width="500"
+			height="400"
+			src="https://www.example.com/"
+			allowfullscreen=true
+			></iframe>';		
 		$clean_html = $purifier->purify($dirty_html);
 		expect($clean_html)->toEqual('<iframe title="Wildlife" width="500" height="400" src="https://www.example.com/" allowfullscreen="true"></iframe>');
 		echo "finished.\n\n";
@@ -288,70 +288,70 @@ class HTMLPurifierTest extends HackTest {
 
 	public function testWebappPolicy() : void {
 		echo "\nrunning testWebappPolicy()...";
-        $policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
-            'b' => vec[],
-            'ul'=> vec[],
-            'li' => vec[],
-            'ol' => vec[],
-            'h2' => vec[],
-            'h4' => vec[],
-            'br' => vec[],
-            'div' => vec[],
-            'strong' => vec[],
-            'del' => vec[],
-            'em' => vec[],
-            'pre' => vec[],
-            'code' => vec[],
-            'table' => vec[],
-            'tbody' => vec[],
-            'td' => vec[],
-            'th' => vec[],
-            'thead' => vec[],
-            'tr' => vec[],
-            'a' => vec['id', 'name', 'href', 'target', 'rel'],
-            'h3' => vec['class'],
-            'p' => vec['class'],
-            'aside' => vec['class'],
-            'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes']
-            ]
-        );
-        $config = HTMLPurifier\HTMLPurifier_Config::createDefault();
-        $purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
-        expect(true)->toNotBeNull();
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
+			'b' => vec[],
+			'ul'=> vec[],
+			'li' => vec[],
+			'ol' => vec[],
+			'h2' => vec[],
+			'h4' => vec[],
+			'br' => vec[],
+			'div' => vec[],
+			'strong' => vec[],
+			'del' => vec[],
+			'em' => vec[],
+			'pre' => vec[],
+			'code' => vec[],
+			'table' => vec[],
+			'tbody' => vec[],
+			'td' => vec[],
+			'th' => vec[],
+			'thead' => vec[],
+			'tr' => vec[],
+			'a' => vec['id', 'name', 'href', 'target', 'rel'],
+			'h3' => vec['class'],
+			'p' => vec['class'],
+			'aside' => vec['class'],
+			'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes']
+			]
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		expect(true)->toNotBeNull();
 		echo "finished.\n\n";
-    }
+	}
 
 	public function testSpecialCharacterValidateUTF8() : void {
 		echo "\nrunning testWebappPolicy()...";
-        $policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
-            'b' => vec[],
-            'ul'=> vec[],
-            'li' => vec[],
-            'ol' => vec[],
-            'h2' => vec[],
-            'h4' => vec[],
-            'br' => vec[],
-            'div' => vec[],
-            'strong' => vec[],
-            'del' => vec[],
-            'em' => vec[],
-            'pre' => vec[],
-            'code' => vec[],
-            'table' => vec[],
-            'tbody' => vec[],
-            'td' => vec[],
-            'th' => vec[],
-            'thead' => vec[],
-            'tr' => vec[],
-            'a' => vec['id', 'name', 'href', 'target', 'rel'],
-            'h3' => vec['class'],
-            'p' => vec['class'],
-            'aside' => vec['class'],
-            'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes']
-            ]
-        );
-        $config = HTMLPurifier\HTMLPurifier_Config::createDefault();
-        $purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
+			'b' => vec[],
+			'ul'=> vec[],
+			'li' => vec[],
+			'ol' => vec[],
+			'h2' => vec[],
+			'h4' => vec[],
+			'br' => vec[],
+			'div' => vec[],
+			'strong' => vec[],
+			'del' => vec[],
+			'em' => vec[],
+			'pre' => vec[],
+			'code' => vec[],
+			'table' => vec[],
+			'tbody' => vec[],
+			'td' => vec[],
+			'th' => vec[],
+			'thead' => vec[],
+			'tr' => vec[],
+			'a' => vec['id', 'name', 'href', 'target', 'rel'],
+			'h3' => vec['class'],
+			'p' => vec['class'],
+			'aside' => vec['class'],
+			'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes']
+			]
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
 		$dirty_html = '<h2>Guest accounts and shared channels</h2>
 <h3>Guest accounts</h3>
 <p>These are great for working with someone who feels like a member of your organization but needs only limited access to Slack.</p>
@@ -435,5 +435,5 @@ class HTMLPurifierTest extends HackTest {
 [aside headline="Invites / admin management" description="" bullets="Guests: Admins must manually provision guest accounts one by one. Admins can choose an automatic expiration date for each guest account  | Shared channels: Once the shared channel is created, both teams can invite others from their workspace to join the channel as projects evolve and additional people need access" /]';
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
-    }
+	}
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -103,12 +103,19 @@ class HTMLPurifierTest extends HackTest {
 </table>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<table><caption>
+		expect($clean_html)->toEqual('<table>
+  <caption>
     Cool table
   </caption>
-  <tfoot><tr><th>I can do so much!</th>
-    </tr></tfoot><tbody><tr><td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
-  </tr></tbody></table>');
+  <tfoot>
+    <tr>
+      <th>I can do so much!</th>
+    </tr>
+  </tfoot>
+  <tbody><tr>
+    <td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
+  </tr>
+</tbody></table>');
 	}
 
 	public function testDOM() : void {
@@ -320,4 +327,55 @@ class HTMLPurifierTest extends HackTest {
         expect(true)->toNotBeNull();
 		echo "finished.\n\n";
     }
+
+	public function testWebappInput(): void {
+		echo "\nrunning testWebappPolicy()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<ul>
+<li>Working with external parties is as straightforward and fluid as working with your own colleagues. </li>
+<li>Both teams have a common place to collaborate, loop in the right people on an as-needed basis, and build a collective repository of knowledge that anyone on either team can add to and reference.</li>
+<li>Both teams can send messages, share files, and access the channel history.</li>
+<li>Any member of the shared channel can also direct-message (DM) any other member in the channel, even if they’re from the other team.</li>
+</ul>';
+
+		$expected_html = '<ul>
+<li>Working with external parties is as straightforward and fluid as working with your own colleagues. </li>
+<li>Both teams have a common place to collaborate, loop in the right people on an as-needed basis, and build a collective repository of knowledge that anyone on either team can add to and reference.</li>
+<li>Both teams can send messages, share files, and access the channel history.</li>
+<li>Any member of the shared channel can also direct-message (DM) any other member in the channel, even if they’re from the other team.</li>
+</ul>';
+
+		$clean_html = $purifier->purify($dirty_html);
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
 }


### PR DESCRIPTION
###  Summary

Complete the implementation of cleanUTF8 since there are few special characters in our blog posts.

Lines that are changed from php html-sanitizer:
https://github.com/ezyang/htmlpurifier/blob/master/library/HTMLPurifier/Encoder.php#L160
https://github.com/ezyang/htmlpurifier/blob/master/library/HTMLPurifier/Encoder.php#L162
https://github.com/ezyang/htmlpurifier/blob/master/library/HTMLPurifier/Encoder.php#L236

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've written tests to cover the new code and functionality included in this PR.
