### PR TITLE
Jw fix diff 4

### DIFF
--- a/src/AttrTransform/ImgRequired.hack
+++ b/src/AttrTransform/ImgRequired.hack
@@ -1,0 +1,50 @@
+// must be called POST validation
+namespace HTMLPurifier\AttrTransform;
+use namespace HTMLPurifier;
+use namespace HH\Lib\C;
+use namespace HH\Lib\Experimental\File;
+/**
+ * Transform that supplies default values for the src and alt attributes
+ * in img tags, as well as prevents the img tag from being removed
+ * because of a missing alt tag. This needs to be registered as both
+ * a pre and post attribute transform.
+ */
+class HTMLPurifier_AttrTransform_ImgRequired extends HTMLPurifier\HTMLPurifier_AttrTransform
+{
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform(
+			dict<string, mixed> $attr,
+			HTMLPurifier\HTMLPurifier_Config $config,
+			HTMLPurifier\HTMLPurifier_Context $context
+		): dict<string, mixed>
+		{
+        $src = true;
+        if (!C\contains_key($attr, 'src')) {
+            if ($config->def->defaults['Core.RemoveInvalidImg']) {
+                return $attr;
+            }
+            $attr['src'] = $config->def->defaults['Attr.DefaultInvalidImage'];
+            $src = false;
+        }
+
+        if (!C\contains_key($attr, 'alt')) {
+            if ($src) {
+                $alt = $config->def->defaults['Attr.DefaultImageAlt'];
+                if ($alt === '') {
+                    $src_path = new File\Path((string) $attr['src']);
+                    $attr['alt'] = $src_path->getBaseName();
+                } else {
+                    $attr['alt'] = $alt;
+                }
+            } else {
+                $attr['alt'] = $config->def->defaults['Attr.DefaultInvalidImageAlt'];
+            }
+        }
+        return $attr;
+    }
+}

--- a/src/Definition/HTMLDefinition.hack
+++ b/src/Definition/HTMLDefinition.hack
@@ -1,7 +1,7 @@
 /* Created by Nikita Ashok and Jake Polacek on 08/04/2020 */
 namespace HTMLPurifier\Definition;
 use namespace HTMLPurifier;
-use namespace HTMLPurifier\{AttrDef, ChildDef};
+use namespace HTMLPurifier\{AttrDef, AttrTransform, ChildDef};
 use namespace HTMLPurifier\AttrDef\HTML;
 use namespace HH\Lib\{C, Str};
 
@@ -425,9 +425,22 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier\HTMLPurifier_Definition {
             "srcset" => new AttrDef\HTMLPurifier_AttrDef_Text(),
             "sizes" => new AttrDef\HTMLPurifier_AttrDef_Text()
         ];
-        $img_element = new HTMLPurifier\HTMLPurifier_ElementDef(true, $img_add_attr, vec[], vec[], vec[], 
-            new ChildDef\HTMLPurifier_ChildDef_Empty(), null, '', false, vec["alt", "src"], vec[],
-            vec[], '', false);
+        $img_element = new HTMLPurifier\HTMLPurifier_ElementDef(
+          true,
+          $img_add_attr,
+          vec[],
+          vec[new AttrTransform\HTMLPurifier_AttrTransform_ImgRequired()],
+          vec[new AttrTransform\HTMLPurifier_AttrTransform_ImgRequired()],
+          new ChildDef\HTMLPurifier_ChildDef_Empty(),
+          null,
+          '',
+          false,
+          vec["alt", "src"],
+          vec[],
+          vec[],
+          '',
+          false
+        );
         $this->info["img"] = $img_element;
 
         $td_add_attr = dict[

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -302,6 +302,21 @@ class HTMLPurifierTest extends HackTest {
 		echo "finished.\n\n";
 	}
 
+	public function testImagePolicyWithMissingAltAttribute() : void {
+		echo "\nrunning testImagePolicyWithMissingAltAttribute()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
+			'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes']
+		]);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<img loading="lazy" class="alignright" src="https://biz-hq.co/request-unlimited-pto@2x.jpg?w=360">';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html = '<img class="alignright" src="https://biz-hq.co/request-unlimited-pto@2x.jpg?w=360" alt="request-unlimited-pto@2x.jpg?w=360">';
+		// do not remove images without alt attributes, add the basename as alt
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
+
 	public function testWebappPolicy() : void {
 		echo "\nrunning testWebappPolicy()...";
 		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
@@ -338,7 +353,7 @@ class HTMLPurifierTest extends HackTest {
 	}
 
 	public function testSpecialCharacterValidateUTF8() : void {
-		echo "\nrunning testWebappPolicy()...";
+		echo "\nrunning testSpecialCharacterValidateUTF8()...";
 		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
 			'b' => vec[],
 			'ul'=> vec[],


### PR DESCRIPTION
###  Summary

Generate a default alt text for an image if one isn't provided. https://jira.tinyspeck.com/browse/PSF-808

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
