### PR TITLE
Fix quote escape when rebuilding HTML

### DIFF
--- a/src/Generator.hack
+++ b/src/Generator.hack
@@ -201,7 +201,7 @@ class HTMLPurifier_Generator {
     public function escape(string $string, int $quote = 0): string {
         // Workaround for APC bug on Mac Leopard reported by sidepodcast
         // http://htmlpurifier.org/phorum/read.php?3,4823,4846
-        if ($quote is null) {
+        if ($quote == 0) {
             $quote = \ENT_COMPAT;
         }
         return \htmlspecialchars($string, $quote, 'UTF-8');

--- a/src/Generator.hack
+++ b/src/Generator.hack
@@ -198,10 +198,10 @@ class HTMLPurifier_Generator {
     }
 
     // Escapes raw text data
-    public function escape(string $string, int $quote = 0): string {
+    public function escape(string $string, int $quote = -1): string {
         // Workaround for APC bug on Mac Leopard reported by sidepodcast
         // http://htmlpurifier.org/phorum/read.php?3,4823,4846
-        if ($quote == 0) {
+        if ($quote === -1) {
             $quote = \ENT_COMPAT;
         }
         return \htmlspecialchars($string, $quote, 'UTF-8');

--- a/src/Generator.hack
+++ b/src/Generator.hack
@@ -198,10 +198,10 @@ class HTMLPurifier_Generator {
     }
 
     // Escapes raw text data
-    public function escape(string $string, int $quote = -1): string {
+    public function escape(string $string, int $quote = 0): string {
         // Workaround for APC bug on Mac Leopard reported by sidepodcast
         // http://htmlpurifier.org/phorum/read.php?3,4823,4846
-        if ($quote === -1) {
+        if ($quote == 0) {
             $quote = \ENT_COMPAT;
         }
         return \htmlspecialchars($string, $quote, 'UTF-8');

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -425,4 +425,45 @@ class HTMLPurifierTest extends HackTest {
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
+
+	public function testQuote(): void {
+		echo "\nrunning testWebappPolicy()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html =
+			'<h3><img loading="lazy" class="alignnone size-full wp-image-1466" src="https://d34u8crftukxnk.cloudfront.net/slackpress/prod/sites/6/at-mention-user-slack%402x.png" alt="Slack UI showing how to use the &quot;at&quot; mention to organize tasks and owners" width="1024" height="579" />How it works</h3>';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html =
+			'<h3><img class="alignnone size-full wp-image-1466" src="https://d34u8crftukxnk.cloudfront.net/slackpress/prod/sites/6/at-mention-user-slack%402x.png" alt="Slack UI showing how to use the &quot;at&quot; mention to organize tasks and owners" width="1024" height="579">How it works</h3>';
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -470,10 +470,10 @@ class HTMLPurifierTest extends HackTest {
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
 		$dirty_html =
-			'<h3><img loading="lazy" class="alignnone size-full wp-image-1466" src="https://d34u8crftukxnk.cloudfront.net/slackpress/prod/sites/6/at-mention-user-slack%402x.png" alt="Slack UI showing how to use the &quot;at&quot; mention to organize tasks and owners" width="1024" height="579" />How it works</h3>';
+			'<h3><img loading="lazy" class="alignnone size-full wp-image-1466" src="https://a1b.cloudfront.net/test/6/at-test-user-test%402x.png" alt="how to use the &quot;at&quot; html sanitizer" width="1024" height="579" />How it works</h3>';
 		$clean_html = $purifier->purify($dirty_html);
 		$expected_html =
-			'<h3><img class="alignnone size-full wp-image-1466" src="https://d34u8crftukxnk.cloudfront.net/slackpress/prod/sites/6/at-mention-user-slack%402x.png" alt="Slack UI showing how to use the &quot;at&quot; mention to organize tasks and owners" width="1024" height="579">How it works</h3>';
+			'<h3><img class="alignnone size-full wp-image-1466" src="https://a1b.cloudfront.net/test/6/at-test-user-test%402x.png" alt="how to use the &quot;at&quot; html sanitizer" width="1024" height="579">How it works</h3>';
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -119,19 +119,12 @@ class HTMLPurifierTest extends HackTest {
 </table>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<table>
-  <caption>
+		expect($clean_html)->toEqual('<table><caption>
 	Cool table
   </caption>
-  <tfoot>
-	<tr>
-	  <th>I can do so much!</th>
-	</tr>
-  </tfoot>
-  <tbody><tr>
-	<td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
-  </tr>
-</tbody></table>');
+  <tfoot><tr><th>I can do so much!</th>
+	</tr></tfoot><tbody><tr><td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
+  </tr></tbody></table>');
 	}
 
 	public function testDOM() : void {
@@ -412,19 +405,15 @@ class HTMLPurifierTest extends HackTest {
 <p>&nbsp;</p>
 [aside headline="Security" description="" bullets="a sentence" /]';
 		$clean_html = $purifier->purify($dirty_html);
-		$expected_html = '<ul>
-<li>Just a sentence. </li>
+		$expected_html = '<ul><li>Just a sentence. </li>
 <li>Just a sentence.</li>
 <li>Just a sentence.</li>
 <li>Just a sentence.</li>
-</ul>
-<h2>Should I?</h2>
+</ul><h2>Should I?</h2>
 <p><strong>If you’re working with…</strong></p>
-<ul>
-<li>An individual – abc</li>
+<ul><li>An individual – abc</li>
 <li>A team – abc</li>
-</ul>
-<p>p tags.</p>
+</ul><p>p tags.</p>
 <h2>header 2</h2>
 [aside headline="Who are you working with?" description="" bullets="a sentence. " /]
 <p> </p>

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -119,12 +119,19 @@ class HTMLPurifierTest extends HackTest {
 </table>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<table><caption>
+		expect($clean_html)->toEqual('<table>
+  <caption>
 	Cool table
   </caption>
-  <tfoot><tr><th>I can do so much!</th>
-	</tr></tfoot><tbody><tr><td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
-  </tr></tbody></table>');
+  <tfoot>
+	<tr>
+	  <th>I can do so much!</th>
+	</tr>
+  </tfoot>
+  <tbody><tr>
+	<td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
+  </tr>
+</tbody></table>');
 	}
 
 	public function testDOM() : void {
@@ -405,15 +412,19 @@ class HTMLPurifierTest extends HackTest {
 <p>&nbsp;</p>
 [aside headline="Security" description="" bullets="a sentence" /]';
 		$clean_html = $purifier->purify($dirty_html);
-		$expected_html = '<ul><li>Just a sentence. </li>
+		$expected_html = '<ul>
+<li>Just a sentence. </li>
 <li>Just a sentence.</li>
 <li>Just a sentence.</li>
 <li>Just a sentence.</li>
-</ul><h2>Should I?</h2>
+</ul>
+<h2>Should I?</h2>
 <p><strong>If you’re working with…</strong></p>
-<ul><li>An individual – abc</li>
+<ul>
+<li>An individual – abc</li>
 <li>A team – abc</li>
-</ul><p>p tags.</p>
+</ul>
+<p>p tags.</p>
 <h2>header 2</h2>
 [aside headline="Who are you working with?" description="" bullets="a sentence. " /]
 <p> </p>


### PR DESCRIPTION
###  Summary

When we rebuild the html, `"` in attribute is not escaped by `htmlspecialchars` function. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
