### PR TITLE
fix allowrel policy

### DIFF
--- a/src/AttrDef/HTML/LinkTypes.hack
+++ b/src/AttrDef/HTML/LinkTypes.hack
@@ -67,13 +67,6 @@ class HTMLPurifier_AttrDef_HTML_LinkTypes extends HTMLPurifier\HTMLPurifier_Attr
             $ret_lookup[$part] = true;
         }
 
-        // make all allowed exist
-        foreach ($allowed as $add => $_) {
-            if (!C\contains_key($ret_lookup, $add)) {
-                $ret_lookup[$add] = true;
-            }
-        }
-
         if (C\is_empty($ret_lookup)) {
             return '';
         }

--- a/src/AttrTransform.hack
+++ b/src/AttrTransform.hack
@@ -11,7 +11,7 @@ use namespace HH\Lib\C;
  */
 abstract class HTMLPurifier_AttrTransform {
     // Makes changes to the attributes dependent on multiple values.
-    abstract public function transform(dict<string, mixed> $attr, HTMLPurifier_Config $config, HTMLPurifier_Context $context): dict<string, mixed>;
+    abstract public function transform(dict<string, string> $attr, HTMLPurifier_Config $config, HTMLPurifier_Context $context): dict<string, string>;
 
     // Prepends CSS properties to the style attribute, creating the attribute if it doesn't exist.
     public function prependCSS(inout dict<string, mixed> $attr, string $css): void {

--- a/src/AttrTransform/ImgRequired.hack
+++ b/src/AttrTransform/ImgRequired.hack
@@ -18,10 +18,10 @@ class HTMLPurifier_AttrTransform_ImgRequired extends HTMLPurifier\HTMLPurifier_A
      * @return array
      */
     public function transform(
-			dict<string, mixed> $attr,
+			dict<string, string> $attr,
 			HTMLPurifier\HTMLPurifier_Config $config,
 			HTMLPurifier\HTMLPurifier_Context $context
-		): dict<string, mixed>
+		): dict<string, string>
 		{
         $src = true;
         if (!C\contains_key($attr, 'src')) {

--- a/src/AttrTransform/TargetBlank.hack
+++ b/src/AttrTransform/TargetBlank.hack
@@ -20,10 +20,10 @@ class HTMLPurifier_AttrTransform_TargetBlank extends HTMLPurifier\HTMLPurifier_A
 	}
 
 	/**
-	* @param dic<string, mixed> $attr
+	* @param dic<string, string> $attr
 	* @param HTMLPurifier_Config $config
 	* @param HTMLPurifier_Context $context
-	* @return dict<string, mixed>
+	* @return dict<string, string>
 	 */
 	public function transform(
 		dict<string, string> $attr,

--- a/src/AttrTransform/TargetBlank.hack
+++ b/src/AttrTransform/TargetBlank.hack
@@ -1,0 +1,45 @@
+namespace HTMLPurifier\AttrTransform;
+use namespace HH\Lib\{C, Str, Vec};
+use namespace HTMLPurifier;
+// must be called POST validation
+
+/**
+ * Adds target="blank" to all outbound links.  This transform is
+ * only attached if Attr.TargetBlank is TRUE.  This works regardless
+ * of whether or not Attr.AllowedFrameTargets
+ */
+class HTMLPurifier_AttrTransform_TargetBlank extends HTMLPurifier\HTMLPurifier_AttrTransform {
+	/**
+	 * @type HTMLPurifier_URIParser
+	 */
+	private HTMLPurifier\HTMLPurifier_URIParser $parser;
+
+	public function __construct() {
+		$this->parser = new HTMLPurifier\HTMLPurifier_URIParser();
+	}
+
+	/**
+	* @param dic<string, mixed> $attr
+	* @param HTMLPurifier_Config $config
+	* @param HTMLPurifier_Context $context
+	* @return dict<string, mixed>
+	 */
+	public function transform(
+		dict<string, mixed> $attr,
+		HTMLPurifier\HTMLPurifier_Config $config,
+		HTMLPurifier\HTMLPurifier_Context $context,
+	): dict<string, mixed> {
+		if (!isset($attr['href'])) {
+			return $attr;
+		}
+
+		// XXX Kind of inefficient
+		$url = $this->parser->parse((string)$attr['href']);
+		$scheme = $url->getSchemeObj($config, $context);
+
+		if ($scheme is nonnull && $scheme->browsable && !$url->isBenign($config, $context)) {
+			$attr['target'] = '_blank';
+		}
+		return $attr;
+	}
+}

--- a/src/AttrTransform/TargetBlank.hack
+++ b/src/AttrTransform/TargetBlank.hack
@@ -35,7 +35,7 @@ class HTMLPurifier_AttrTransform_TargetBlank extends HTMLPurifier\HTMLPurifier_A
 		}
 
 		// XXX Kind of inefficient
-		$url = $this->parser->parse((string)$attr['href']);
+		$url = $this->parser->parse($attr['href']);
 		$scheme = $url->getSchemeObj($config, $context);
 
 		if ($scheme is nonnull && $scheme->browsable && !$url->isBenign($config, $context)) {

--- a/src/AttrTransform/TargetBlank.hack
+++ b/src/AttrTransform/TargetBlank.hack
@@ -26,11 +26,11 @@ class HTMLPurifier_AttrTransform_TargetBlank extends HTMLPurifier\HTMLPurifier_A
 	* @return dict<string, mixed>
 	 */
 	public function transform(
-		dict<string, mixed> $attr,
+		dict<string, string> $attr,
 		HTMLPurifier\HTMLPurifier_Config $config,
 		HTMLPurifier\HTMLPurifier_Context $context,
-	): dict<string, mixed> {
-		if (!isset($attr['href'])) {
+	): dict<string, string> {
+		if (!C\contains_key($attr, 'href')) {
 			return $attr;
 		}
 

--- a/src/AttrTransform/TargetBlank.hack
+++ b/src/AttrTransform/TargetBlank.hack
@@ -1,3 +1,4 @@
+/* Created by Chenkai Gao on 11/16/2020 */
 namespace HTMLPurifier\AttrTransform;
 use namespace HH\Lib\{C, Str, Vec};
 use namespace HTMLPurifier;

--- a/src/AttrTransform/TargetBlank.hack
+++ b/src/AttrTransform/TargetBlank.hack
@@ -30,6 +30,10 @@ class HTMLPurifier_AttrTransform_TargetBlank extends HTMLPurifier\HTMLPurifier_A
 		HTMLPurifier\HTMLPurifier_Config $config,
 		HTMLPurifier\HTMLPurifier_Context $context,
 	): dict<string, string> {
+		if (!$config->def->defaults['HTML.TargetBlank']) {
+			# This transform is turned off in the configuration
+			return $attr;
+		}
 		if (!C\contains_key($attr, 'href')) {
 			return $attr;
 		}

--- a/src/AttrTransform/TargetNoopener.hack
+++ b/src/AttrTransform/TargetNoopener.hack
@@ -28,7 +28,7 @@ class HTMLPurifier_AttrTransform_TargetNoopener extends HTMLPurifier\HTMLPurifie
 			return $attr;
 		}
 		if (C\contains_key($attr, 'rel')) {
-			$rels = Str\split((string)$attr['rel'], ' ');
+			$rels = Str\split($attr['rel'], ' ');
 		} else {
 			$rels = vec<string>[];
 		}

--- a/src/AttrTransform/TargetNoopener.hack
+++ b/src/AttrTransform/TargetNoopener.hack
@@ -13,17 +13,17 @@ use namespace HTMLPurifier;
  */
 class HTMLPurifier_AttrTransform_TargetNoopener extends HTMLPurifier\HTMLPurifier_AttrTransform {
 	/**
-	 * @param dic<string, mixed> $attr
+	 * @param dic<string, string> $attr
 	 * @param HTMLPurifier_Config $config
 	 * @param HTMLPurifier_Context $context
-	 * @return dict<string, mixed>
+	 * @return dict<string, string>
 	 */
 	public function transform(
 		dict<string, string> $attr,
 		HTMLPurifier\HTMLPurifier_Config $config,
 		HTMLPurifier\HTMLPurifier_Context $context,
 	): dict<string, string> {
-		if (C\contains_key($attr, 'rel') && $attr['rel'] is string) {
+		if (C\contains_key($attr, 'rel')) {
 			$rels = Str\split((string)$attr['rel'], ' ');
 		} else {
 			$rels = vec<string>[];

--- a/src/AttrTransform/TargetNoopener.hack
+++ b/src/AttrTransform/TargetNoopener.hack
@@ -23,6 +23,10 @@ class HTMLPurifier_AttrTransform_TargetNoopener extends HTMLPurifier\HTMLPurifie
 		HTMLPurifier\HTMLPurifier_Config $config,
 		HTMLPurifier\HTMLPurifier_Context $context,
 	): dict<string, string> {
+		if (!$config->def->defaults['HTML.TargetNoopener']) {
+			# This transform is turned off in the configuration
+			return $attr;
+		}
 		if (C\contains_key($attr, 'rel')) {
 			$rels = Str\split((string)$attr['rel'], ' ');
 		} else {

--- a/src/AttrTransform/TargetNoopener.hack
+++ b/src/AttrTransform/TargetNoopener.hack
@@ -19,19 +19,19 @@ class HTMLPurifier_AttrTransform_TargetNoopener extends HTMLPurifier\HTMLPurifie
 	 * @return dict<string, mixed>
 	 */
 	public function transform(
-		dict<string, mixed> $attr,
+		dict<string, string> $attr,
 		HTMLPurifier\HTMLPurifier_Config $config,
 		HTMLPurifier\HTMLPurifier_Context $context,
-	): dict<string, mixed> {
-		if (isset($attr['rel']) && $attr['rel'] is string) {
+	): dict<string, string> {
+		if (C\contains_key($attr, 'rel') && $attr['rel'] is string) {
 			$rels = Str\split((string)$attr['rel'], ' ');
 		} else {
 			$rels = vec<string>[];
 		}
-		if (isset($attr['target']) && !C\contains($rels, 'noopener')) {
+		if (C\contains_key($attr, 'target') && !C\contains($rels, 'noopener')) {
 			$rels[] = 'noopener';
 		}
-		if (!C\is_empty($rels) || isset($attr['rel'])) {
+		if (!C\is_empty($rels) || C\contains_key($attr, 'rel')) {
 			$attr['rel'] = Str\join($rels, ' ');
 		}
 

--- a/src/AttrTransform/TargetNoopener.hack
+++ b/src/AttrTransform/TargetNoopener.hack
@@ -1,3 +1,4 @@
+/* Created by Chenkai Gao on 11/16/2020 */
 namespace HTMLPurifier\AttrTransform;
 use namespace HH\Lib\{C, Str, Vec};
 use namespace HTMLPurifier;

--- a/src/AttrTransform/TargetNoopener.hack
+++ b/src/AttrTransform/TargetNoopener.hack
@@ -1,0 +1,39 @@
+namespace HTMLPurifier\AttrTransform;
+use namespace HH\Lib\{C, Str, Vec};
+use namespace HTMLPurifier;
+// must be called POST validation
+
+/**
+ * Adds rel="noopener" to any links which target a different window
+ * than the current one.  This is used to prevent malicious websites
+ * from silently replacing the original window, which could be used
+ * to do phishing.
+ * This transform is controlled by %HTML.TargetNoopener.
+ */
+class HTMLPurifier_AttrTransform_TargetNoopener extends HTMLPurifier\HTMLPurifier_AttrTransform {
+	/**
+	 * @param dic<string, mixed> $attr
+	 * @param HTMLPurifier_Config $config
+	 * @param HTMLPurifier_Context $context
+	 * @return dict<string, mixed>
+	 */
+	public function transform(
+		dict<string, mixed> $attr,
+		HTMLPurifier\HTMLPurifier_Config $config,
+		HTMLPurifier\HTMLPurifier_Context $context,
+	): dict<string, mixed> {
+		if (isset($attr['rel']) && $attr['rel'] is string) {
+			$rels = Str\split((string)$attr['rel'], ' ');
+		} else {
+			$rels = vec<string>[];
+		}
+		if (isset($attr['target']) && !C\contains($rels, 'noopener')) {
+			$rels[] = 'noopener';
+		}
+		if (!C\is_empty($rels) || isset($attr['rel'])) {
+			$attr['rel'] = Str\join($rels, ' ');
+		}
+
+		return $attr;
+	}
+}

--- a/src/AttrTransform/TargetNoreferrer.hack
+++ b/src/AttrTransform/TargetNoreferrer.hack
@@ -13,17 +13,17 @@ use namespace HTMLPurifier;
  */
 class HTMLPurifier_AttrTransform_TargetNoreferrer extends HTMLPurifier\HTMLPurifier_AttrTransform {
 	/**
-	* @param dic<string, mixed> $attr
+	* @param dic<string, string> $attr
 	* @param HTMLPurifier_Config $config
 	* @param HTMLPurifier_Context $context
-	* @return dict<string, mixed>
+	* @return dict<string, string>
 	 */
 	public function transform(
 		dict<string, string> $attr,
 		HTMLPurifier\HTMLPurifier_Config $config,
 		HTMLPurifier\HTMLPurifier_Context $context,
 	): dict<string, string> {
-		if (C\contains_key($attr, 'rel') && $attr['rel'] is string) {
+		if (C\contains_key($attr, 'rel')) {
 			$rels = Str\split((string)$attr['rel'], ' ');
 		} else {
 			$rels = array();

--- a/src/AttrTransform/TargetNoreferrer.hack
+++ b/src/AttrTransform/TargetNoreferrer.hack
@@ -30,7 +30,7 @@ class HTMLPurifier_AttrTransform_TargetNoreferrer extends HTMLPurifier\HTMLPurif
 		if (C\contains_key($attr, 'rel')) {
 			$rels = Str\split($attr['rel'], ' ');
 		} else {
-			$rels = array();
+			$rels = vec<string>[];
 		}
 		if (C\contains_key($attr, 'target') && !C\contains($rels, 'noreferrer')) {
 			$rels[] = 'noreferrer';

--- a/src/AttrTransform/TargetNoreferrer.hack
+++ b/src/AttrTransform/TargetNoreferrer.hack
@@ -1,0 +1,40 @@
+
+namespace HTMLPurifier\AttrTransform;
+use namespace HH\Lib\{C, Str, Vec};
+use namespace HTMLPurifier;
+// must be called POST validation
+
+/**
+ * Adds rel="noreferrer" to any links which target a different window
+ * than the current one.  This is used to prevent malicious websites
+ * from silently replacing the original window, which could be used
+ * to do phishing.
+ * This transform is controlled by %HTML.TargetNoreferrer.
+ */
+class HTMLPurifier_AttrTransform_TargetNoreferrer extends HTMLPurifier\HTMLPurifier_AttrTransform {
+	/**
+	* @param dic<string, mixed> $attr
+	* @param HTMLPurifier_Config $config
+	* @param HTMLPurifier_Context $context
+	* @return dict<string, mixed>
+	 */
+	public function transform(
+		dict<string, mixed> $attr,
+		HTMLPurifier\HTMLPurifier_Config $config,
+		HTMLPurifier\HTMLPurifier_Context $context,
+	): dict<string, mixed> {
+		if (isset($attr['rel']) && $attr['rel'] is string) {
+			$rels = Str\split((string)$attr['rel'], ' ');
+		} else {
+			$rels = array();
+		}
+		if (isset($attr['target']) && !C\contains($rels, 'noreferrer')) {
+			$rels[] = 'noreferrer';
+		}
+		if (!C\is_empty($rels) || isset($attr['rel'])) {
+			$attr['rel'] = Str\join($rels, ' ');
+		}
+
+		return $attr;
+	}
+}

--- a/src/AttrTransform/TargetNoreferrer.hack
+++ b/src/AttrTransform/TargetNoreferrer.hack
@@ -1,4 +1,4 @@
-
+/* Created by Chenkai Gao on 11/16/2020 */
 namespace HTMLPurifier\AttrTransform;
 use namespace HH\Lib\{C, Str, Vec};
 use namespace HTMLPurifier;

--- a/src/AttrTransform/TargetNoreferrer.hack
+++ b/src/AttrTransform/TargetNoreferrer.hack
@@ -28,7 +28,7 @@ class HTMLPurifier_AttrTransform_TargetNoreferrer extends HTMLPurifier\HTMLPurif
 			return $attr;
 		}
 		if (C\contains_key($attr, 'rel')) {
-			$rels = Str\split((string)$attr['rel'], ' ');
+			$rels = Str\split($attr['rel'], ' ');
 		} else {
 			$rels = array();
 		}

--- a/src/AttrTransform/TargetNoreferrer.hack
+++ b/src/AttrTransform/TargetNoreferrer.hack
@@ -23,6 +23,10 @@ class HTMLPurifier_AttrTransform_TargetNoreferrer extends HTMLPurifier\HTMLPurif
 		HTMLPurifier\HTMLPurifier_Config $config,
 		HTMLPurifier\HTMLPurifier_Context $context,
 	): dict<string, string> {
+		if (!$config->def->defaults['HTML.TargetNoreferrer']) {
+			# This transform is turned off in the configuration
+			return $attr;
+		}
 		if (C\contains_key($attr, 'rel')) {
 			$rels = Str\split((string)$attr['rel'], ' ');
 		} else {

--- a/src/AttrTransform/TargetNoreferrer.hack
+++ b/src/AttrTransform/TargetNoreferrer.hack
@@ -19,19 +19,19 @@ class HTMLPurifier_AttrTransform_TargetNoreferrer extends HTMLPurifier\HTMLPurif
 	* @return dict<string, mixed>
 	 */
 	public function transform(
-		dict<string, mixed> $attr,
+		dict<string, string> $attr,
 		HTMLPurifier\HTMLPurifier_Config $config,
 		HTMLPurifier\HTMLPurifier_Context $context,
-	): dict<string, mixed> {
-		if (isset($attr['rel']) && $attr['rel'] is string) {
+	): dict<string, string> {
+		if (C\contains_key($attr, 'rel') && $attr['rel'] is string) {
 			$rels = Str\split((string)$attr['rel'], ' ');
 		} else {
 			$rels = array();
 		}
-		if (isset($attr['target']) && !C\contains($rels, 'noreferrer')) {
+		if (C\contains_key($attr, 'target') && !C\contains($rels, 'noreferrer')) {
 			$rels[] = 'noreferrer';
 		}
-		if (!C\is_empty($rels) || isset($attr['rel'])) {
+		if (!C\is_empty($rels) || C\contains_key($attr, 'rel')) {
 			$attr['rel'] = Str\join($rels, ' ');
 		}
 

--- a/src/AttrValidator.hack
+++ b/src/AttrValidator.hack
@@ -81,11 +81,10 @@ class HTMLPurifier_AttrValidator {
         $defs = $definition->info[$token->name]->attr;
 
 
-		$context->register('CurrentAttr', false);
+        $context->register('CurrentAttr', false);
 
         // iterate through all the attribute keypairs
         // Watch out for name collisions: $key has previously been used
-        // $attr = $spec->assertType($attr);
         foreach ($attr as $attr_key => $value) {
             //$attr_key = (string)$attr_key;
             // call the definition

--- a/src/AttrValidator.hack
+++ b/src/AttrValidator.hack
@@ -95,10 +95,10 @@ class HTMLPurifier_AttrValidator {
                     // that must be overridden.
                     // Theoretically speaking, we could have a
                     // AttrDef_DenyAll, but this is faster!
-                    $result = false;
+                    $result = null;
                 } else {
                     // validate according to the element's definition
-                    $value = (string)$value;
+                    $value = $value;
                     $result = $defs[$attr_key]->validate(
                         $value,
                         $config,
@@ -108,7 +108,7 @@ class HTMLPurifier_AttrValidator {
             } elseif (C\contains_key($d_defs, $attr_key)) {
                 // there is a global definition defined, validate according
                 // to the global definition
-                $value = (string)$value;
+                $value = $value;
                 $result = $d_defs[$attr_key]->validate(
                     $value,
                     $config,
@@ -116,11 +116,11 @@ class HTMLPurifier_AttrValidator {
                 );
             } else {
                 // system never heard of the attribute? DELETE!
-                $result = false;
+                $result = null;
             }
 
             // put the results into effect
-            if (($result === '' && $value !== '') || $result === false || $result === null) {
+            if (($result === '' && $value !== '') ||  $result === null) {
                 // this is a generic error message that should replaced
                 // with more specific ones when possible
                 // if ($e) {
@@ -135,7 +135,7 @@ class HTMLPurifier_AttrValidator {
                 // delegate it to the attribute classes to say exactly what.
 
                 // simple substitution
-                $attr[$attr_key] = (string)$result;
+                $attr[$attr_key] = $result;
             } else {
                 // nothing happens
             }

--- a/src/AttrValidator.hack
+++ b/src/AttrValidator.hack
@@ -135,7 +135,7 @@ class HTMLPurifier_AttrValidator {
                 // delegate it to the attribute classes to say exactly what.
 
                 // simple substitution
-                $attr[$attr_key] = $result;
+                $attr[$attr_key] = (string)$result;
             } else {
                 // nothing happens
             }

--- a/src/AttrValidator.hack
+++ b/src/AttrValidator.hack
@@ -86,7 +86,6 @@ class HTMLPurifier_AttrValidator {
         // iterate through all the attribute keypairs
         // Watch out for name collisions: $key has previously been used
         foreach ($attr as $attr_key => $value) {
-            //$attr_key = (string)$attr_key;
             // call the definition
             if (C\contains_key($defs, $attr_key)) {
                 // there is a local definition definedcod
@@ -136,7 +135,7 @@ class HTMLPurifier_AttrValidator {
                 // delegate it to the attribute classes to say exactly what.
 
                 // simple substitution
-                $attr[$attr_key] = (string)$result;
+                $attr[$attr_key] = $result;
             } else {
                 // nothing happens
             }

--- a/src/AttrValidator.hack
+++ b/src/AttrValidator.hack
@@ -80,14 +80,14 @@ class HTMLPurifier_AttrValidator {
         // DEFINITION CALL
         $defs = $definition->info[$token->name]->attr;
 
-        $attr_key = false;
-        $context->register('CurrentAttr', $attr_key);
+
+		$context->register('CurrentAttr', false);
 
         // iterate through all the attribute keypairs
         // Watch out for name collisions: $key has previously been used
         // $attr = $spec->assertType($attr);
         foreach ($attr as $attr_key => $value) {
-            $attr_key = (string)$attr_key;
+            //$attr_key = (string)$attr_key;
             // call the definition
             if (C\contains_key($defs, $attr_key)) {
                 // there is a local definition definedcod
@@ -137,7 +137,7 @@ class HTMLPurifier_AttrValidator {
                 // delegate it to the attribute classes to say exactly what.
 
                 // simple substitution
-                $attr[$attr_key] = $result;
+                $attr[$attr_key] = (string)$result;
             } else {
                 // nothing happens
             }

--- a/src/ConfigSchema.hack
+++ b/src/ConfigSchema.hack
@@ -409,7 +409,7 @@ class HTMLPurifier_ConfigSchema {
             "Attr.AllowedClasses" => dict[],
             "Attr.ForbiddenClasses" => dict[],
             "Attr.AllowedFrameTargets" => vec[],
-			"Attr.AllowedRel" => dict["noopener" => true, "noreferrer" => true],
+            "Attr.AllowedRel" => dict["noopener" => true, "noreferrer" => true],
             "Attr.AllowedRev" => dict[],
             "Attr.ClassUseCDATA" => null,
             "Attr.DefaultImageAlt" => '',

--- a/src/ConfigSchema.hack
+++ b/src/ConfigSchema.hack
@@ -409,7 +409,7 @@ class HTMLPurifier_ConfigSchema {
             "Attr.AllowedClasses" => dict[],
             "Attr.ForbiddenClasses" => dict[],
             "Attr.AllowedFrameTargets" => vec[],
-            "Attr.AllowedRel" => dict["noopener" => true, "noreferrer" => true],
+            "Attr.AllowedRel" => dict[],
             "Attr.AllowedRev" => dict[],
             "Attr.ClassUseCDATA" => null,
             "Attr.DefaultImageAlt" => '',

--- a/src/ConfigSchema.hack
+++ b/src/ConfigSchema.hack
@@ -409,7 +409,7 @@ class HTMLPurifier_ConfigSchema {
             "Attr.AllowedClasses" => dict[],
             "Attr.ForbiddenClasses" => dict[],
             "Attr.AllowedFrameTargets" => vec[],
-            "Attr.AllowedRel" => dict[],
+			"Attr.AllowedRel" => dict["noopener" => true, "noreferrer" => true],
             "Attr.AllowedRev" => dict[],
             "Attr.ClassUseCDATA" => null,
             "Attr.DefaultImageAlt" => '',

--- a/src/Definition/HTMLDefinition.hack
+++ b/src/Definition/HTMLDefinition.hack
@@ -258,7 +258,17 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier\HTMLPurifier_Definition {
             "target" => new HTML\HTMLPurifier_AttrDef_HTML_FrameTarget(vec["_blank"]),
             "href" => new AttrDef\HTMLPurifier_AttrDef_URI()
         ];
-        $a_element = new HTMLPurifier\HTMLPurifier_ElementDef(true, $a_add_attr, vec[], vec[], vec[], new ChildDef\HTMLPurifier_ChildDef_Optional(),
+		$a_element = new HTMLPurifier\HTMLPurifier_ElementDef(
+			true,
+			$a_add_attr,
+			vec[],
+			vec[],
+			vec[
+				new HTMLPurifier\AttrTransform\HTMLPurifier_AttrTransform_TargetBlank(),
+				new HTMLPurifier\AttrTransform\HTMLPurifier_AttrTransform_TargetNoopener(),
+				new HTMLPurifier\AttrTransform\HTMLPurifier_AttrTransform_TargetNoreferrer(),
+			],
+			new ChildDef\HTMLPurifier_ChildDef_Optional(),
                     null, '', true, vec[], vec['a'], vec[], '', true);
         $this->info["a"] = $a_element;
 

--- a/src/Lexer/DOMLex.hack
+++ b/src/Lexer/DOMLex.hack
@@ -149,7 +149,7 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier\HTMLPurifier_Lexer {
             return false;
         }
 
-        $attr = $node->hasAttributes() ? $this->transformAttrToAssoc($node->attributes) : dict<string, mixed>[];
+        $attr = $node->hasAttributes() ? $this->transformAttrToAssoc($node->attributes) : dict<string, string>[];
         //not sure if hack domnode's have tag name
         $tag_name = $this->getTagName($node);
         if (!$tag_name) {
@@ -179,7 +179,7 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier\HTMLPurifier_Lexer {
     }
 
     // Converts a DOMNamedNodeMap of DOMAttr objects into an assoc array.
-    protected function transformAttrToAssoc(?\DOMNamedNodeMap<\DOMAttr> $node_map): dict<string, mixed> {
+    protected function transformAttrToAssoc(?\DOMNamedNodeMap<\DOMAttr> $node_map): dict<string, string> {
         $node_map = $node_map;
         if ($node_map is null) {
             throw new \Exception('Node Map should be nonnull, but it is null');

--- a/src/Node/Element.hack
+++ b/src/Node/Element.hack
@@ -9,7 +9,7 @@ use namespace HTMLPurifier\Token;
  */
 class HTMLPurifier_Node_Element extends HTMLPurifier\HTMLPurifier_Node {
     public string $name;
-    public dict<string, mixed> $attr = dict[];
+    public dict<string, string> $attr = dict[];
     public vec<HTMLPurifier\HTMLPurifier_Node> $children = vec[];
     /**
      * Does this use the <a></a> form or the </a> form, i.e.
@@ -21,7 +21,13 @@ class HTMLPurifier_Node_Element extends HTMLPurifier\HTMLPurifier_Node {
     public int $endLine = 0;
     public vec<string> $endArmor = vec[];
 
-    public function __construct(string $name, dict<string, mixed> $attr = dict[], int $line=0, int $col=0, vec<string> $armor=vec[]) {
+	public function __construct(
+		string $name,
+		dict<string, string> $attr = dict[],
+		int $line = 0,
+		int $col = 0,
+		vec<string> $armor = vec[],
+	) {
         $this->name = $name;
         $this->attr = $attr;
         $this->line = $line;

--- a/src/Token/Tag.hack
+++ b/src/Token/Tag.hack
@@ -10,9 +10,9 @@ use namespace HH\Lib\{Dict, Str};
 class HTMLPurifier_Token_Tag extends HTMLPurifier\HTMLPurifier_Token {
     public bool $is_tag = true;
     public string $name;
-    public dict<string, mixed> $attr = dict[];
+    public dict<string, string> $attr = dict[];
 
-    public function __construct(string $name, dict<string, mixed> $attr = dict[], int $line=0, int $col=0, vec<string> $armor = vec[]) {
+    public function __construct(string $name, dict<string, string> $attr = dict[], int $line=0, int $col=0, vec<string> $armor = vec[]) {
         $this->name = Str\lowercase($name);
         if (!$attr) {
             $attr = dict[];

--- a/src/TokenFactory.hack
+++ b/src/TokenFactory.hack
@@ -21,7 +21,7 @@ class HTMLPurifier_TokenFactory {
         $this->p_comment = new Token\HTMLPurifier_Token_Comment('');
     }
 
-    public function createStart(string $name, dict<string, mixed> $attr): Token\HTMLPurifier_Token_Start {
+    public function createStart(string $name, dict<string, string> $attr): Token\HTMLPurifier_Token_Start {
         return new Token\HTMLPurifier_Token_Start($name, $attr);
     }
 
@@ -29,7 +29,7 @@ class HTMLPurifier_TokenFactory {
         return new Token\HTMLPurifier_Token_End($name);
     }
 
-    public function createEmpty(string $name, dict<string, mixed> $attr = dict[]): Token\HTMLPurifier_Token_Empty {
+    public function createEmpty(string $name, dict<string, string> $attr = dict[]): Token\HTMLPurifier_Token_Empty {
         return new Token\HTMLPurifier_Token_Empty($name, $attr);
     }
 

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -466,7 +466,7 @@ class HTMLPurifierTest extends HackTest {
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
-*/
+
 	public function testRel(): void {
 		echo "\nrunning testRel()...";
 		$policy = new HTMLPurifier\HTMLPurifier_Policy(

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -701,4 +701,18 @@ class HTMLPurifierTest extends HackTest {
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
+
+	public function testDisabledTargetBlankTransform(): void {
+		echo "\nrunning testAtagNoTarget()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict['a' => vec['id', 'name', 'href', 'target', 'rel']],
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<a href="https://google.com"></a>';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html = '<a href="https://google.com"></a>';
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -464,4 +464,43 @@ class HTMLPurifierTest extends HackTest {
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
+
+	public function testAtagTargetAttribute(): void {
+		echo "\nrunning testAtagTargetAttribute()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<p><a name="bobcat" target="_blank"></a></p>';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html = '<p><a name="bobcat" target="_blank"></a></p>';
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -545,4 +545,160 @@ class HTMLPurifierTest extends HackTest {
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
+
+	public function testAtagNoChange(): void {
+		echo "\nrunning testAtagNoChange()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<p><a name="bobcat" target="_blank" rel="noopener noreferrer"></a></p>';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html = '<p><a name="bobcat" target="_blank" rel="noopener noreferrer"></a></p>';
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
+
+	public function testAtagStripAdd(): void {
+		echo "\nrunning testAtagStripAdd()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<p><a name="bobcat" target="_blank" rel="ab" target="_blank"></a></p>';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html = '<p><a name="bobcat" target="_blank" rel="noopener noreferrer"></a></p>';
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
+
+	public function testAtagStripLeave(): void {
+		echo "\nrunning testAtagStripLeave()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<p><a name="bobcat" target="_blank" rel="ab noopener noreferrer"></a></p>';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html = '<p><a name="bobcat" target="_blank" rel="noopener noreferrer"></a></p>';
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
+
+	public function testAtagNoTarget(): void {
+		echo "\nrunning testAtagNoTarget()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<p><a name="bobcat" rel="noopener noreferrer"></a></p>';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html = '<p><a name="bobcat" rel="noopener noreferrer"></a></p>';
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -466,7 +466,7 @@ class HTMLPurifierTest extends HackTest {
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
-
+*/
 	public function testRel(): void {
 		echo "\nrunning testRel()...";
 		$policy = new HTMLPurifier\HTMLPurifier_Policy(
@@ -506,6 +506,7 @@ class HTMLPurifierTest extends HackTest {
 		echo "finished.\n\n";
 	}
 
+
 	public function testAtagTargetAttribute(): void {
 		echo "\nrunning testAtagTargetAttribute()...";
 		$policy = new HTMLPurifier\HTMLPurifier_Policy(
@@ -538,9 +539,9 @@ class HTMLPurifierTest extends HackTest {
 		);
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
-		$dirty_html = '<p><a name="bobcat" target="_blank"></a></p>';
+		$dirty_html = '<p><a name="bobcat" target="_blank" rel="noopener noreferrer"></a></p>';
 		$clean_html = $purifier->purify($dirty_html);
-		$expected_html = '<p><a name="bobcat" target="_blank"></a></p>';
+		$expected_html = '<p><a name="bobcat" target="_blank" rel="noopener noreferrer"></a></p>';
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -425,4 +425,43 @@ class HTMLPurifierTest extends HackTest {
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
+
+	public function testRel(): void {
+		echo "\nrunning testRel()...";
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
+		);
+		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
+		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
+		$dirty_html = '<p><a rel="ab" name="bobcat"></a></p>';
+		$clean_html = $purifier->purify($dirty_html);
+		$expected_html = '<p><a name="bobcat"></a></p>';
+		expect($clean_html)->toEqual($expected_html);
+		echo "finished.\n\n";
+	}
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -539,7 +539,7 @@ class HTMLPurifierTest extends HackTest {
 		);
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
-		$dirty_html = '<p><a name="bobcat" target="_blank" rel="noopener noreferrer"></a></p>';
+		$dirty_html = '<p><a name="bobcat" target="_blank"></a></p>';
 		$clean_html = $purifier->purify($dirty_html);
 		$expected_html = '<p><a name="bobcat" target="_blank" rel="noopener noreferrer"></a></p>';
 		expect($clean_html)->toEqual($expected_html);


### PR DESCRIPTION
###  Summary

The cause is that we need to do a post attribute transform for <a> tag. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
