### PR TITLE
Upgrade composer for HHVM 4.56

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,8 +12,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.39'
-          - '4.41'
+          - '4.56'
     runs-on: ${{matrix.os}}-latest
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,13 @@
 	"name": "slackhq/htmlsanitizer-hack",
 	"description": "Slack Hack HTML Sanitizer",
 	"require": {
-		"hhvm/hhast": "^4.33.5",
-		"facebook/fbexpect": "^2.7.3",
+		"hhvm/hhast": "^4.53.4",
+		"facebook/fbexpect": "^2.7.4",
 		"hhvm/hhvm-autoload": "^2.0|^3.0",
-		"hhvm/hacktest": "^2.0.0",
-		"hhvm/hsl": "^4.36.0",
-		"hhvm/hsl-experimental": "^4.37.3",
-		"facebook/hack-codegen": "^4.3.2"
+		"hhvm/hacktest": "^2.1.0",
+		"hhvm/hsl": "^4.41.0",
+		"hhvm/hsl-experimental": "^4.50.0",
+		"facebook/hack-codegen": "^4.3.8"
 	},
 	"scripts": {
 		"post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80a3618a8de99214feef1aca647928a0",
+    "content-hash": "3ba1c3481c620b9904fcc53f023dc360",
     "packages": [
         {
             "name": "facebook/difflib",
@@ -48,21 +48,21 @@
         },
         {
             "name": "facebook/fbexpect",
-            "version": "v2.7.5",
+            "version": "v2.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/fbexpect.git",
-                "reference": "62e2c39741e1c86c373da3ab75617dbedfaed419"
+                "reference": "edae1a4d746bb4af21fd8f65431ba467ebf34cc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/62e2c39741e1c86c373da3ab75617dbedfaed419",
-                "reference": "62e2c39741e1c86c373da3ab75617dbedfaed419",
+                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/edae1a4d746bb4af21fd8f65431ba467ebf34cc1",
+                "reference": "edae1a4d746bb4af21fd8f65431ba467ebf34cc1",
                 "shasum": ""
             },
             "require": {
                 "facebook/difflib": "^1.0.0",
-                "hhvm": "^4.25",
+                "hhvm": "^4.45",
                 "hhvm/hacktest": "^1.0|^2.0",
                 "hhvm/hsl": "^4.0"
             },
@@ -78,9 +78,9 @@
             "description": "Unit test helpers for Facebook projects",
             "support": {
                 "issues": "https://github.com/hhvm/fbexpect/issues",
-                "source": "https://github.com/hhvm/fbexpect/tree/v2.7.5"
+                "source": "https://github.com/hhvm/fbexpect/tree/v2.7.8"
             },
-            "time": "2020-07-29T17:03:08+00:00"
+            "time": "2020-12-11T21:53:22+00:00"
         },
         {
             "name": "facebook/hack-codegen",
@@ -149,27 +149,28 @@
         },
         {
             "name": "facebook/hh-clilib",
-            "version": "v2.2.4",
+            "version": "v2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hh-clilib.git",
-                "reference": "7e5a0acdae42ab33b332f94f43cfcf25636bddee"
+                "reference": "77bef1f893d77f8b7711fa83d72f2a11508f5888"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/7e5a0acdae42ab33b332f94f43cfcf25636bddee",
-                "reference": "7e5a0acdae42ab33b332f94f43cfcf25636bddee",
+                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/77bef1f893d77f8b7711fa83d72f2a11508f5888",
+                "reference": "77bef1f893d77f8b7711fa83d72f2a11508f5888",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.13",
+                "hhvm": "^4.41",
                 "hhvm/hsl": "^4.0",
-                "hhvm/hsl-experimental": "^4.0",
-                "hhvm/type-assert": "^3.2"
+                "hhvm/hsl-experimental": "^4.52",
+                "hhvm/hsl-io": "^0.1.0",
+                "hhvm/type-assert": "^3.0|^4.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.6.1",
-                "hhvm/hacktest": "^1.0.0",
+                "hhvm/hacktest": "^2.0",
                 "hhvm/hhast": "^4.0.2"
             },
             "type": "library",
@@ -184,30 +185,32 @@
             ],
             "support": {
                 "issues": "https://github.com/hhvm/hh-clilib/issues",
-                "source": "https://github.com/hhvm/hh-clilib/tree/v2.2.4"
+                "source": "https://github.com/hhvm/hh-clilib/tree/v2.4.2"
             },
-            "time": "2019-11-07T21:21:31+00:00"
+            "time": "2020-05-21T15:52:05+00:00"
         },
         {
             "name": "hhvm/hacktest",
-            "version": "v2.0.1",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hacktest.git",
-                "reference": "cde86b675923d56955a2f0f95840206e52bd8618"
+                "reference": "27e507447d7a115004ddb1d20c9ee0ab561c4153"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hacktest/zipball/cde86b675923d56955a2f0f95840206e52bd8618",
-                "reference": "cde86b675923d56955a2f0f95840206e52bd8618",
+                "url": "https://api.github.com/repos/hhvm/hacktest/zipball/27e507447d7a115004ddb1d20c9ee0ab561c4153",
+                "reference": "27e507447d7a115004ddb1d20c9ee0ab561c4153",
                 "shasum": ""
             },
             "require": {
-                "facebook/hh-clilib": "^2.0.0",
-                "hhvm": "^4.15",
+                "facebook/hh-clilib": "^2.3.0",
+                "hhvm": "^4.41",
                 "hhvm/hhvm-autoload": "^2.0.2|^3.0",
                 "hhvm/hsl": "^4.0",
-                "hhvm/type-assert": "^3.2"
+                "hhvm/hsl-experimental": "^4.50",
+                "hhvm/hsl-io": "^0.1.0",
+                "hhvm/type-assert": "^3.0|^4.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.3.0",
@@ -232,30 +235,30 @@
                 "issues": "https://github.com/hhvm/hacktest/issues",
                 "source": "https://github.com/hhvm/hacktest/tree/master"
             },
-            "time": "2020-02-07T21:57:16+00:00"
+            "time": "2020-05-21T15:48:09+00:00"
         },
         {
             "name": "hhvm/hhast",
-            "version": "v4.33.9",
+            "version": "v4.53.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhast.git",
-                "reference": "9f586c80055f73c17b95742ec97627c1d11a1deb"
+                "reference": "2a9e8ce25568d6cce861821ff69831c43838fe6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhast/zipball/9f586c80055f73c17b95742ec97627c1d11a1deb",
-                "reference": "9f586c80055f73c17b95742ec97627c1d11a1deb",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/2a9e8ce25568d6cce861821ff69831c43838fe6e",
+                "reference": "2a9e8ce25568d6cce861821ff69831c43838fe6e",
                 "shasum": ""
             },
             "require": {
                 "facebook/difflib": "^1.0.0",
                 "facebook/hh-clilib": "^2.0.0",
-                "hhvm": "^4.33",
+                "hhvm": "^4.53",
                 "hhvm/hhvm-autoload": "^2.0.4|^3.0",
                 "hhvm/hsl": "^4.25",
-                "hhvm/hsl-experimental": "^4.25",
-                "hhvm/type-assert": "^3.4"
+                "hhvm/hsl-experimental": "^4.50",
+                "hhvm/type-assert": "^3.0|^4.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.1.1",
@@ -283,9 +286,9 @@
             "description": "A mutable AST library for Hack with linting and code migrations",
             "support": {
                 "issues": "https://github.com/hhvm/hhast/issues",
-                "source": "https://github.com/hhvm/hhast/tree/v4.33.9"
+                "source": "https://github.com/hhvm/hhast/tree/v4.53.4"
             },
-            "time": "2020-02-28T18:38:22+00:00"
+            "time": "2020-05-21T15:55:34+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",
@@ -341,26 +344,26 @@
         },
         {
             "name": "hhvm/hsl",
-            "version": "v4.40.0",
+            "version": "v4.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hsl.git",
-                "reference": "b14a430062ad95c378765899f955457f3454f2f9"
+                "reference": "80a42c02f036f72a42f0415e80d6b847f4bf62d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hsl/zipball/b14a430062ad95c378765899f955457f3454f2f9",
-                "reference": "b14a430062ad95c378765899f955457f3454f2f9",
+                "url": "https://api.github.com/repos/hhvm/hsl/zipball/80a42c02f036f72a42f0415e80d6b847f4bf62d5",
+                "reference": "80a42c02f036f72a42f0415e80d6b847f4bf62d5",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.25"
+                "hhvm": "^4.41"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.5.1",
                 "hhvm/hacktest": "^1.0|^2.0",
-                "hhvm/hhvm-autoload": "^2.0",
-                "hhvm/hsl-experimental": "dev-master"
+                "hhvm/hhvm-autoload": "^2.0|^3.0",
+                "hhvm/hsl-experimental": "^4.37|dev-master"
             },
             "type": "library",
             "extra": {
@@ -375,31 +378,33 @@
             "description": "The Hack Standard Library",
             "support": {
                 "issues": "https://github.com/hhvm/hsl/issues",
-                "source": "https://github.com/hhvm/hsl/tree/master"
+                "source": "https://github.com/hhvm/hsl/tree/v4.41.0"
             },
-            "time": "2020-01-08T23:12:08+00:00"
+            "time": "2020-05-01T23:05:23+00:00"
         },
         {
             "name": "hhvm/hsl-experimental",
-            "version": "v4.37.3",
+            "version": "v4.52.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hsl-experimental.git",
-                "reference": "e0306dc237d0b3a92eddefb8b4d6b6047a43229d"
+                "reference": "ba8cfb8b920af493c51ed11b3a7ac09f8d7f67c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hsl-experimental/zipball/e0306dc237d0b3a92eddefb8b4d6b6047a43229d",
-                "reference": "e0306dc237d0b3a92eddefb8b4d6b6047a43229d",
+                "url": "https://api.github.com/repos/hhvm/hsl-experimental/zipball/ba8cfb8b920af493c51ed11b3a7ac09f8d7f67c6",
+                "reference": "ba8cfb8b920af493c51ed11b3a7ac09f8d7f67c6",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.25",
+                "hhvm": "^4.52",
                 "hhvm/hsl": "^4.15"
+            },
+            "provide": {
+                "hhvm/hsl-io": "0.1.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.7.0",
-                "facebook/hh-clilib": ">= v2.2.4 <2.3.0",
                 "hhvm/hacktest": "^2.0",
                 "hhvm/hhvm-autoload": "^2.0|^3.0"
             },
@@ -416,22 +421,22 @@
             "description": "The Hack Standard Library - Experimental Additions",
             "support": {
                 "issues": "https://github.com/hhvm/hsl-experimental/issues",
-                "source": "https://github.com/hhvm/hsl-experimental/tree/v4.37"
+                "source": "https://github.com/hhvm/hsl-experimental/tree/v4.52.x"
             },
-            "time": "2020-04-16T21:25:40+00:00"
+            "time": "2020-05-19T21:08:17+00:00"
         },
         {
             "name": "hhvm/type-assert",
-            "version": "v3.7.3",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/type-assert.git",
-                "reference": "e076c42ed718929dbea96c0b354ebe96cccc2335"
+                "reference": "3aa45a566dce60277462853a0dc84f439ecb33bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/e076c42ed718929dbea96c0b354ebe96cccc2335",
-                "reference": "e076c42ed718929dbea96c0b354ebe96cccc2335",
+                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/3aa45a566dce60277462853a0dc84f439ecb33bf",
+                "reference": "3aa45a566dce60277462853a0dc84f439ecb33bf",
                 "shasum": ""
             },
             "require": {
@@ -442,7 +447,7 @@
                 "facebook/fbexpect": "^2.0.0",
                 "hhvm/hacktest": "^2.0",
                 "hhvm/hhast": "^4.0",
-                "hhvm/hhvm-autoload": "^2.0"
+                "hhvm/hhvm-autoload": "^2.0|^3.0"
             },
             "type": "library",
             "extra": {
@@ -461,9 +466,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hhvm/type-assert/issues",
-                "source": "https://github.com/hhvm/type-assert/tree/v3.7.3"
+                "source": "https://github.com/hhvm/type-assert/tree/master"
             },
-            "time": "2020-01-13T21:48:58+00:00"
+            "time": "2020-05-20T18:49:02+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/AttrTransform/ImgRequired.hack
+++ b/src/AttrTransform/ImgRequired.hack
@@ -2,49 +2,47 @@
 namespace HTMLPurifier\AttrTransform;
 use namespace HTMLPurifier;
 use namespace HH\Lib\C;
-use namespace HH\Lib\Experimental\File;
+use namespace HH\Lib\File;
 /**
  * Transform that supplies default values for the src and alt attributes
  * in img tags, as well as prevents the img tag from being removed
  * because of a missing alt tag. This needs to be registered as both
  * a pre and post attribute transform.
  */
-class HTMLPurifier_AttrTransform_ImgRequired extends HTMLPurifier\HTMLPurifier_AttrTransform
-{
-    /**
-     * @param array $attr
-     * @param HTMLPurifier_Config $config
-     * @param HTMLPurifier_Context $context
-     * @return array
-     */
-    public function transform(
-			dict<string, string> $attr,
-			HTMLPurifier\HTMLPurifier_Config $config,
-			HTMLPurifier\HTMLPurifier_Context $context
-		): dict<string, string>
-		{
-        $src = true;
-        if (!C\contains_key($attr, 'src')) {
-            if ($config->def->defaults['Core.RemoveInvalidImg']) {
-                return $attr;
-            }
-            $attr['src'] = $config->def->defaults['Attr.DefaultInvalidImage'];
-            $src = false;
-        }
+class HTMLPurifier_AttrTransform_ImgRequired extends HTMLPurifier\HTMLPurifier_AttrTransform {
+	/**
+	 * @param array $attr
+	 * @param HTMLPurifier_Config $config
+	 * @param HTMLPurifier_Context $context
+	 * @return array
+	 */
+	public function transform(
+		dict<string, string> $attr,
+		HTMLPurifier\HTMLPurifier_Config $config,
+		HTMLPurifier\HTMLPurifier_Context $context,
+	): dict<string, string> {
+		$src = true;
+		if (!C\contains_key($attr, 'src')) {
+			if ($config->def->defaults['Core.RemoveInvalidImg']) {
+				return $attr;
+			}
+			$attr['src'] = $config->def->defaults['Attr.DefaultInvalidImage'];
+			$src = false;
+		}
 
-        if (!C\contains_key($attr, 'alt')) {
-            if ($src) {
-                $alt = $config->def->defaults['Attr.DefaultImageAlt'];
-                if ($alt === '') {
-                    $src_path = new File\Path((string) $attr['src']);
-                    $attr['alt'] = $src_path->getBaseName();
-                } else {
-                    $attr['alt'] = $alt;
-                }
-            } else {
-                $attr['alt'] = $config->def->defaults['Attr.DefaultInvalidImageAlt'];
-            }
-        }
-        return $attr;
-    }
+		if (!C\contains_key($attr, 'alt')) {
+			if ($src) {
+				$alt = $config->def->defaults['Attr.DefaultImageAlt'];
+				if ($alt === '') {
+					$src_path = new File\Path((string)$attr['src']);
+					$attr['alt'] = $src_path->getBaseName();
+				} else {
+					$attr['alt'] = $alt;
+				}
+			} else {
+				$attr['alt'] = $config->def->defaults['Attr.DefaultInvalidImageAlt'];
+			}
+		}
+		return $attr;
+	}
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -119,12 +119,19 @@ class HTMLPurifierTest extends HackTest {
 </table>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<table><caption>
+		expect($clean_html)->toEqual('<table>
+  <caption>
 	Cool table
   </caption>
-  <tfoot><tr><th>I can do so much!</th>
-	</tr></tfoot><tbody><tr><td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
-  </tr></tbody></table>');
+  <tfoot>
+	<tr>
+	  <th>I can do so much!</th>
+	</tr>
+  </tfoot>
+  <tbody><tr>
+	<td style="font-size:16pt;color:#F00;font-family:sans-serif;text-align:center;">Wow</td>
+  </tr>
+</tbody></table>');
 	}
 
 	public function testDOM(): void {
@@ -425,15 +432,19 @@ class HTMLPurifierTest extends HackTest {
 <p>&nbsp;</p>
 [aside headline="Security" description="" bullets="a sentence" /]';
 		$clean_html = $purifier->purify($dirty_html);
-		$expected_html = '<ul><li>Just a sentence. </li>
+		$expected_html = '<ul>
+<li>Just a sentence. </li>
 <li>Just a sentence.</li>
 <li>Just a sentence.</li>
 <li>Just a sentence.</li>
-</ul><h2>Should I?</h2>
+</ul>
+<h2>Should I?</h2>
 <p><strong>If you’re working with…</strong></p>
-<ul><li>An individual – abc</li>
+<ul>
+<li>An individual – abc</li>
 <li>A team – abc</li>
-</ul><p>p tags.</p>
+</ul>
+<p>p tags.</p>
 <h2>header 2</h2>
 [aside headline="Who are you working with?" description="" bullets="a sentence. " /]
 <p> </p>

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -8,8 +8,8 @@ use namespace HTMLPurifier;
 use namespace HTMLPurifier\{Strategy, Token, Lexer};
 
 class HTMLPurifierTest extends HackTest {
-	
-	public function testMissingEndTags() : void {
+
+	public function testMissingEndTags(): void {
 		echo "\nrunning testMissingEndTags()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
@@ -21,7 +21,7 @@ class HTMLPurifierTest extends HackTest {
 		echo "finished.\n\n";
 	}
 
-	public function testMaliciousCodeRemoved() : void {
+	public function testMaliciousCodeRemoved(): void {
 		echo "\ntestMaliciousCodeRemoved()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
@@ -33,7 +33,7 @@ class HTMLPurifierTest extends HackTest {
 		echo "finished.\n\n";
 	}
 
-	public function testMaliciousCodeRemovedWithText() : void {
+	public function testMaliciousCodeRemovedWithText(): void {
 		echo "\ntestMaliciousCodeRemovedWithText()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
@@ -45,7 +45,7 @@ class HTMLPurifierTest extends HackTest {
 		echo "finished.\n\n";
 	}
 
-	public function testIllegalNestingFixed() : void {
+	public function testIllegalNestingFixed(): void {
 		echo "\ntestIllegalNestingFixed()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
@@ -57,7 +57,7 @@ class HTMLPurifierTest extends HackTest {
 		echo "finished.\n\n";
 	}
 
-	public function testDeprecatedTagsConverted() : void {
+	public function testDeprecatedTagsConverted(): void {
 		echo "\ntestDeprecatedTagsConverted()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
@@ -69,7 +69,7 @@ class HTMLPurifierTest extends HackTest {
 		echo "finished.\n\n";
 	}
 
-	public function testCSSValidated() : void {
+	public function testCSSValidated(): void {
 		echo "\ntestCSSValidated()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
@@ -84,7 +84,7 @@ class HTMLPurifierTest extends HackTest {
 	public function testMaintainSuperfluousDivs(): void {
 		echo "\ntestMaintainSuperfluousDivs()...";
 		// porting over first config classes....
-		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict["h2"=>vec[], "div"=>vec[]]);
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict["h2" => vec[], "div" => vec[]]);
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$dirty_html = '<div class="style1">
 <div class="style2">
@@ -97,7 +97,7 @@ class HTMLPurifierTest extends HackTest {
 		expect($clean_html)->toEqual($dirty_html);
 	}
 
-	public function testRichFormattingPreserved() : void {
+	public function testRichFormattingPreserved(): void {
 		echo "\ntestRichFormattingPreserved()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
@@ -127,7 +127,7 @@ class HTMLPurifierTest extends HackTest {
   </tr></tbody></table>');
 	}
 
-	public function testDOM() : void {
+	public function testDOM(): void {
 		echo "\nrunning testDOM()...";
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$context = new HTMLPurifier\HTMLPurifier_Context();
@@ -135,17 +135,18 @@ class HTMLPurifierTest extends HackTest {
 		$html = "<b>Bold";
 		$lexer = new Lexer\HTMLPurifier_Lexer_DOMLex();
 		$tokens = $lexer->tokenizeHTML($html, $config, $context);
-		
+
 		$expected_tokens = vec[
 			new Token\HTMLPurifier_Token_Start("b", dict[]),
 			new Token\HTMLPurifier_Token_Text("Bold"),
-			new Token\HTMLPurifier_Token_End("b", dict[])];
+			new Token\HTMLPurifier_Token_End("b", dict[]),
+		];
 
 		expect($tokens)->toHaveSameContentAs($expected_tokens);
 		echo "finished.\n";
 	}
 
-	public function testStrategies() : void {
+	public function testStrategies(): void {
 		echo "\nrunning testStrategies()...";
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$context = new HTMLPurifier\HTMLPurifier_Context();
@@ -155,9 +156,11 @@ class HTMLPurifierTest extends HackTest {
 		$fix_nesting = new Strategy\HTMLPurifier_Strategy_FixNesting();
 		$validate_attributes = new Strategy\HTMLPurifier_Strategy_ValidateAttributes();
 
-		$tokens = vec[new Token\HTMLPurifier_Token_Start("b", dict[]),
+		$tokens = vec[
+			new Token\HTMLPurifier_Token_Start("b", dict[]),
 			new Token\HTMLPurifier_Token_Text("Text"),
-			new Token\HTMLPurifier_Token_End("b", dict[])];
+			new Token\HTMLPurifier_Token_End("b", dict[]),
+		];
 
 		$rfe_tokens = $remove_foreign_elements->execute($tokens, $config, $context);
 		$mwf_tokens = $make_well_formed->execute($tokens, $config, $context);
@@ -187,7 +190,7 @@ class HTMLPurifierTest extends HackTest {
 		echo "\nrunning testPolicyAllowListUnCleanWithPolicyDict()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
-  		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict["a"=>vec[]]);
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict["a" => vec[]]);
 		$dirty_html = '<b>Hello';
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
 		$clean_html = $purifier->purify($dirty_html);
@@ -223,8 +226,8 @@ class HTMLPurifierTest extends HackTest {
 		echo "\nrunning testPolicyAllowListClean()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
-  		$config->def->defaults['HTML.Allowed'] = "div[align]";
-  		$dirty_html = '<div align="center" title="hi"><b>Hello</b>';
+		$config->def->defaults['HTML.Allowed'] = "div[align]";
+		$dirty_html = '<div align="center" title="hi"><b>Hello</b>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
 		expect($clean_html)->toEqual('<div align="center">Hello</div>');
@@ -236,13 +239,17 @@ class HTMLPurifierTest extends HackTest {
 		echo "\nrunning testSanitizeHtmlWithIframeForVideoPolicySet()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
-  		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict["iframe"=>vec["title","width","height","src","allowfullscreen"]]);
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict["iframe" => vec["title", "width", "height", "src", "allowfullscreen"]],
+		);
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
 
 
 		$dirty_html = '<iframe src="https://www.example.com/watch?v=M84hFmNhTQU" height="364" width="576"></iframe>';
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<iframe src="https://www.example.com/watch?v=M84hFmNhTQU" height="364" width="576"></iframe>');
+		expect($clean_html)->toEqual(
+			'<iframe src="https://www.example.com/watch?v=M84hFmNhTQU" height="364" width="576"></iframe>',
+		);
 		echo "finished.\n\n";
 	}
 
@@ -250,7 +257,9 @@ class HTMLPurifierTest extends HackTest {
 		echo "\nrunning testSanitizeHtmlWithIframeForSearchProtocolsPolicySet()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
-  		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict["iframe"=>vec["title","width","height","src","allowfullscreen"]]);
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict["iframe" => vec["title", "width", "height", "src", "allowfullscreen"]],
+		);
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
 
 		// Test1 clean iframe with usertesting domain with no protocol
@@ -262,7 +271,9 @@ class HTMLPurifierTest extends HackTest {
 			allowfullscreen=true
 			></iframe>';
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<iframe title="Wildlife" width="500" height="400" src="//www.example.com" allowfullscreen="true"></iframe>');
+		expect($clean_html)->toEqual(
+			'<iframe title="Wildlife" width="500" height="400" src="//www.example.com" allowfullscreen="true"></iframe>',
+		);
 
 		$dirty_html = '<iframe
 			title="Wildlife"
@@ -270,9 +281,11 @@ class HTMLPurifierTest extends HackTest {
 			height="400"
 			src="https://www.example.com/"
 			allowfullscreen=true
-			></iframe>';		
+			></iframe>';
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<iframe title="Wildlife" width="500" height="400" src="https://www.example.com/" allowfullscreen="true"></iframe>');
+		expect($clean_html)->toEqual(
+			'<iframe title="Wildlife" width="500" height="400" src="https://www.example.com/" allowfullscreen="true"></iframe>',
+		);
 		echo "finished.\n\n";
 	}
 
@@ -286,65 +299,71 @@ class HTMLPurifierTest extends HackTest {
 		$dirty_html = '<a href="http://localhost">foo</a>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
-		expect($clean_html)->toEqual('<a href="/redirect.php?url=http%3A%2F%2Flocalhost&amp;check=c0efad89696082f5cb925d28636b0f4260f346391c92c70c8e9eba72591c2a73">foo</a>');
+		expect($clean_html)->toEqual(
+			'<a href="/redirect.php?url=http%3A%2F%2Flocalhost&amp;check=c0efad89696082f5cb925d28636b0f4260f346391c92c70c8e9eba72591c2a73">foo</a>',
+		);
 	}
 
-	public function testPercentageHeightWidth() : void {
+	public function testPercentageHeightWidth(): void {
 		echo "\nrunning testPercentageHeightWidth()...";
 		//porting over first config classes....
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 
-		$dirty_html = '<iframe src="https://example.com/videoclip/abc123?autoplay=true&origin=slack" height="100%" width="100%" allow="fullscreen" allowfullscreen="true" frameborder="0"></iframe>';
+		$dirty_html =
+			'<iframe src="https://example.com/videoclip/abc123?autoplay=true&origin=slack" height="100%" width="100%" allow="fullscreen" allowfullscreen="true" frameborder="0"></iframe>';
 		$purifier = new HTMLPurifier\HTMLPurifier($config);
 		$clean_html = $purifier->purify($dirty_html);
-		$expected_html = '<iframe src="https://example.com/videoclip/abc123?autoplay=true&amp;origin=slack" height="100%" width="100%" allowfullscreen="true"></iframe>';
+		$expected_html =
+			'<iframe src="https://example.com/videoclip/abc123?autoplay=true&amp;origin=slack" height="100%" width="100%" allowfullscreen="true"></iframe>';
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
 
-	public function testImagePolicyWithMissingAltAttribute() : void {
+	public function testImagePolicyWithMissingAltAttribute(): void {
 		echo "\nrunning testImagePolicyWithMissingAltAttribute()...";
 		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
-			'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes']
+			'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
 		]);
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
 		$dirty_html = '<img loading="lazy" class="alignright" src="https://biz-hq.co/request-unlimited-pto@2x.jpg?w=360">';
 		$clean_html = $purifier->purify($dirty_html);
-		$expected_html = '<img class="alignright" src="https://biz-hq.co/request-unlimited-pto@2x.jpg?w=360" alt="request-unlimited-pto@2x.jpg?w=360">';
+		$expected_html =
+			'<img class="alignright" src="https://biz-hq.co/request-unlimited-pto@2x.jpg?w=360" alt="request-unlimited-pto@2x.jpg?w=360">';
 		// do not remove images without alt attributes, add the basename as alt
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
 
-	public function testWebappPolicy() : void {
+	public function testWebappPolicy(): void {
 		echo "\nrunning testWebappPolicy()...";
-		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
-			'b' => vec[],
-			'ul'=> vec[],
-			'li' => vec[],
-			'ol' => vec[],
-			'h2' => vec[],
-			'h4' => vec[],
-			'br' => vec[],
-			'div' => vec[],
-			'strong' => vec[],
-			'del' => vec[],
-			'em' => vec[],
-			'pre' => vec[],
-			'code' => vec[],
-			'table' => vec[],
-			'tbody' => vec[],
-			'td' => vec[],
-			'th' => vec[],
-			'thead' => vec[],
-			'tr' => vec[],
-			'a' => vec['id', 'name', 'href', 'target', 'rel'],
-			'h3' => vec['class'],
-			'p' => vec['class'],
-			'aside' => vec['class'],
-			'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes']
-			]
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
 		);
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
@@ -352,34 +371,35 @@ class HTMLPurifierTest extends HackTest {
 		echo "finished.\n\n";
 	}
 
-	public function testSpecialCharacterValidateUTF8() : void {
+	public function testSpecialCharacterValidateUTF8(): void {
 		echo "\nrunning testSpecialCharacterValidateUTF8()...";
-		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict[
-			'b' => vec[],
-			'ul'=> vec[],
-			'li' => vec[],
-			'ol' => vec[],
-			'h2' => vec[],
-			'h4' => vec[],
-			'br' => vec[],
-			'div' => vec[],
-			'strong' => vec[],
-			'del' => vec[],
-			'em' => vec[],
-			'pre' => vec[],
-			'code' => vec[],
-			'table' => vec[],
-			'tbody' => vec[],
-			'td' => vec[],
-			'th' => vec[],
-			'thead' => vec[],
-			'tr' => vec[],
-			'a' => vec['id', 'name', 'href', 'target', 'rel'],
-			'h3' => vec['class'],
-			'p' => vec['class'],
-			'aside' => vec['class'],
-			'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes']
-			]
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(
+			dict[
+				'b' => vec[],
+				'ul' => vec[],
+				'li' => vec[],
+				'ol' => vec[],
+				'h2' => vec[],
+				'h4' => vec[],
+				'br' => vec[],
+				'div' => vec[],
+				'strong' => vec[],
+				'del' => vec[],
+				'em' => vec[],
+				'pre' => vec[],
+				'code' => vec[],
+				'table' => vec[],
+				'tbody' => vec[],
+				'td' => vec[],
+				'th' => vec[],
+				'thead' => vec[],
+				'tr' => vec[],
+				'a' => vec['id', 'name', 'href', 'target', 'rel'],
+				'h3' => vec['class'],
+				'p' => vec['class'],
+				'aside' => vec['class'],
+				'img' => vec['src', 'alt', 'class', 'width', 'height', 'srcset', 'sizes'],
+			],
 		);
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
@@ -704,9 +724,7 @@ class HTMLPurifierTest extends HackTest {
 
 	public function testDisabledTargetBlankTransform(): void {
 		echo "\nrunning testAtagNoTarget()...";
-		$policy = new HTMLPurifier\HTMLPurifier_Policy(
-			dict['a' => vec['id', 'name', 'href', 'target', 'rel']],
-		);
+		$policy = new HTMLPurifier\HTMLPurifier_Policy(dict['a' => vec['id', 'name', 'href', 'target', 'rel']]);
 		$config = HTMLPurifier\HTMLPurifier_Config::createDefault();
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
 		$dirty_html = '<a href="https://google.com"></a>';


### PR DESCRIPTION
###  Summary
Need to upgrade Slack to HHVM 4.56, and a dependency in this library on HHAST is blocking our upgrade.
Updated all vendored libraries to match `webapp` and re-ran composer install. Updated the import path for `File`. Have 2 tests failing that I need help resolving!
### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [NA] I've written tests to cover the new code and functionality included in this PR.
