### PR TITLE
fix one typechecker error on hhvm 4.102, and run tests on this release

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,7 @@ jobs:
         os: [ ubuntu ]
         hhvm:
           - '4.80'
+          - '4.102'
     runs-on: ${{matrix.os}}-latest
     steps:
       - uses: actions/checkout@v2

--- a/.hhconfig
+++ b/.hhconfig
@@ -14,4 +14,4 @@ hackfmt.line_width=120
 hackfmt.add_trailing_commas=true
 user_attributes=
 allowed_decl_fixme_codes=2053,4047
-allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4047,4104,4107,4108,4110,4128,4135,4188,4240,4323
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4047,4104,4107,4108,4110,4128,4135,4188,4240,4323,4390

--- a/src/AttrDef/CSS.hack
+++ b/src/AttrDef/CSS.hack
@@ -31,7 +31,6 @@ class HTMLPurifier_AttrDef_CSS extends HTMLPurifier\HTMLPurifier_AttrDef {
         $definition = TypeAssert\instance_of(Definition\HTMLPurifier_CSSDefinition::class, $config->getCSSDefinition());
         $allow_duplicates = $config->def->defaults["CSS.AllowDuplicates"];
 
-
         // According to the CSS2.1 spec, the places where a
         // non-delimiting semicolon can appear are in strings
         // escape sequences.   So here is some dumb hack to

--- a/src/AttrDef/CSS/Font.hack
+++ b/src/AttrDef/CSS/Font.hack
@@ -125,7 +125,6 @@ class HTMLPurifier_AttrDef_CSS_Font extends HTMLPurifier\HTMLPurifier_AttrDef {
         $final = ''; // output
         $r = '';
 
-
         for ($i = 0, $size = C\count($bits); $i < $size; $i++) {
             if ($bits[$i] === '') {
                 continue;

--- a/src/AttrDef/CSS/FontFamily.hack
+++ b/src/AttrDef/CSS/FontFamily.hack
@@ -6,7 +6,6 @@ use namespace HTMLPurifier\AttrDef;
 use namespace HH\Lib\{C, Str};
 use namespace Facebook\TypeSpec;
 
-
 /**
  * Validates a font family list according to CSS spec
  */

--- a/src/AttrDef/CSS/ListStyle.hack
+++ b/src/AttrDef/CSS/ListStyle.hack
@@ -16,7 +16,6 @@ class HTMLPurifier_AttrDef_CSS_ListStyle extends HTMLPurifier\HTMLPurifier_AttrD
      */
     protected dict<string, HTMLPurifier\HTMLPurifier_AttrDef> $info = dict[];
 
-
     public function __construct(HTMLPurifier\HTMLPurifier_Config $_config) : void {
         $this->info['list-style-type'] = new AttrDef\HTMLPurifier_AttrDef_Enum(
             vec[

--- a/src/AttrDef/CSS/Number.hack
+++ b/src/AttrDef/CSS/Number.hack
@@ -42,6 +42,7 @@ class HTMLPurifier_AttrDef_CSS_Number extends HTMLPurifier\HTMLPurifier_AttrDef 
                 // FALLTHROUGH
             case '+':
                 $number = Str\slice($number, 1);
+                // FALLTHROUGH
             default: // Do nothing (required in newer hhvm versions)
         }
 

--- a/src/AttrDef/URI.hack
+++ b/src/AttrDef/URI.hack
@@ -49,7 +49,6 @@ class HTMLPurifier_AttrDef_URI extends HTMLPurifier\HTMLPurifier_AttrDef
 
         $ok = false;
         do {
-
             // generic validation
             $result = $uri->validate($config, $context);
             if (!$result) {

--- a/src/AttrValidator.hack
+++ b/src/AttrValidator.hack
@@ -80,7 +80,6 @@ class HTMLPurifier_AttrValidator {
         // DEFINITION CALL
         $defs = $definition->info[$token->name]->attr;
 
-
         $context->register('CurrentAttr', false);
 
         // iterate through all the attribute keypairs

--- a/src/Config.hack
+++ b/src/Config.hack
@@ -28,7 +28,6 @@ class HTMLPurifier_Config {
     public bool $chatty = true;
     private string $lock = '';
 
-
     public function __construct(HTMLPurifier_ConfigSchema $definition, ?HTMLPurifier_PropertyList $parent = null) {
         $parent = $parent ? $parent : $definition->defaultPlist;
         $this->def = $definition;

--- a/src/Definition/CSSDefinition.hack
+++ b/src/Definition/CSSDefinition.hack
@@ -126,7 +126,6 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier\HTMLPurifier_Definition {
         $this->info['border-right-color'] = $this->info['border-top-color'];
         $border_color = $this->info['border-top-color'];
 
-
         $this->info['background'] = new CSS\HTMLPurifier_AttrDef_CSS_Background($config);
 
         $this->info['border-color'] = new CSS\HTMLPurifier_AttrDef_CSS_Multiple($border_color);
@@ -298,7 +297,6 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier\HTMLPurifier_Definition {
                                         );
             $this->info['max-width'] = $this->info['max-height'];
         }
-
 
         $this->info['text-decoration'] = new CSS\HTMLPurifier_AttrDef_CSS_TextDecoration();
 

--- a/src/Definition/HTMLDefinition.hack
+++ b/src/Definition/HTMLDefinition.hack
@@ -1820,7 +1820,6 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier\HTMLPurifier_Definition {
 
 	}
 
-
 	// RAW CUSTOMIZATION STUFF --------------------------------------------
 
 	/**
@@ -1875,14 +1874,12 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier\HTMLPurifier_Definition {
 
 	private ?HTMLPurifier\HTMLPurifier_HTMLModule $_anonModule = null;
 
-
 	/**
 	 * @param HTMLPurifier_Config $config
 	 */
 	protected function doSetup(HTMLPurifier\HTMLPurifier_Config $config): void {
 		$this->setupConfigStuff($config);
 	}
-
 
 	/**
 	 * Sets up stuff based on config. We need a better way of doing this.
@@ -1899,7 +1896,6 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier\HTMLPurifier_Definition {
 		} else {
 			throw new \Error('Cannot use non-block element as block wrapper', \E_USER_ERROR);
 		}
-
 
 		// support template text
 		$support =
@@ -2026,7 +2022,6 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier\HTMLPurifier_Definition {
 				}
 			}
 		}
-
 
 		// setup injectors -----------------------------------------------------
 		foreach ($this->info_injector as $i => $injector) {

--- a/src/Definition/URIDefinition.hack
+++ b/src/Definition/URIDefinition.hack
@@ -99,7 +99,6 @@ class HTMLPurifier_URIDefinition extends HTMLPurifier\HTMLPurifier_Definition {
         }
     }
 
-
     public function filter(inout HTMLPurifier\HTMLPurifier_URI $uri, HTMLPurifier\HTMLPurifier_Config $config, HTMLPurifier\HTMLPurifier_Context $context): bool {
         foreach ($this->filters as $name => $f) {
             $result = $f->filter(inout $uri, $config, $context);
@@ -107,7 +106,6 @@ class HTMLPurifier_URIDefinition extends HTMLPurifier\HTMLPurifier_Definition {
         }
         return true;
     }
-
 
     public function postFilter(inout HTMLPurifier\HTMLPurifier_URI $uri, HTMLPurifier\HTMLPurifier_Config $config, HTMLPurifier\HTMLPurifier_Context $context): bool {
         foreach ($this->postFilters as $name => $f) {

--- a/src/Doctype.hack
+++ b/src/Doctype.hack
@@ -9,11 +9,9 @@ class HTMLPurifier_Doctype {
     // // Full name of doctype
     // public ?string $name;
 
-
     // //  * List of standard modules (string identifiers or literal objects)
     // //  * that this doctype uses
     // public ?vec<string> $modules = vec[];
-
 
     // //  List of modules to use for tidying up code
     // public ?vec<string> $tidyModules = vec[];
@@ -21,13 +19,11 @@ class HTMLPurifier_Doctype {
     // //  Is the language derived from XML (i.e. XHTML)?
     // public ?bool $xml = true;
 
-
     // // List of aliases for this doctype
     // public ?vec<string> $aliases = vec[];
 
     // // Public DTD identifier
     // public ?string $dtdPublic;
-
 
     // // System DTD identifier
     // public ?string $dtdSystem;

--- a/src/Encoder.hack
+++ b/src/Encoder.hack
@@ -224,7 +224,6 @@ class HTMLPurifier_Encoder {
                             // Codepoints outside the Unicode range are illegal
                             ($mUcs4 > 0x10FFFF)
                         ) {
-
                         } elseif (
                             0xFEFF != $mUcs4 && // omit BOM
                             // check for valid Char unicode codepoints

--- a/src/EntityParser.hack
+++ b/src/EntityParser.hack
@@ -25,5 +25,4 @@ class HTMLPurifier_EntityParser {
         return '';
     }
 
-
 }

--- a/src/Generator.hack
+++ b/src/Generator.hack
@@ -34,7 +34,6 @@ class HTMLPurifier_Generator {
     //Configuration for the generator
     protected HTMLPurifier_Config $config;
 
-
     public function __construct(HTMLPurifier_Config $config, HTMLPurifier_Context $context) {
         $this->config = $config;
         $this->scriptFix = $config->def->defaults['Output.CommentScriptContents'];

--- a/src/HTMLModuleManager.hack
+++ b/src/HTMLModuleManager.hack
@@ -71,7 +71,6 @@ class HTMLPurifier_HTMLModuleManager {
     
     public HTMLPurifier_AttrTypes $attrTypes;
 
-
     public function __construct()
     {
         // editable internal objects

--- a/src/Injector/DisplayLinkURI.hack
+++ b/src/Injector/DisplayLinkURI.hack
@@ -20,7 +20,6 @@ class HTMLPurifier_Injector_DisplayLinkURI extends HTMLPurifier\HTMLPurifier_Inj
      */
     public dict<string, vec<string>> $needed = dict['a' => vec[]];
 
-
     /**
      * @param HTMLPurifier_Token $token
      */

--- a/src/Lexer/DOMLex.hack
+++ b/src/Lexer/DOMLex.hack
@@ -5,7 +5,6 @@ use namespace HTMLPurifier;
 use namespace HH\Lib\{C, Regex, Str};
 use namespace HTMLPurifier\Token;
 
-
 /**
  * Parser that uses Hacklang DOMNode.
  */

--- a/src/Node/Text.hack
+++ b/src/Node/Text.hack
@@ -23,5 +23,4 @@ class HTMLPurifier_Node_Text extends HTMLPurifier\HTMLPurifier_Node {
         return tuple(new Token\HTMLPurifier_Token_Text($this->data, $this->line, $this->col), null);
     }
 
-
 }

--- a/src/PropertyList.hack
+++ b/src/PropertyList.hack
@@ -17,7 +17,6 @@ class HTMLPurifier_PropertyList {
     //cache
     protected keyset<arraykey> $cache = keyset[];
 
-
     public function __construct(?HTMLPurifier_PropertyList $parent = null) {
         $this->parent = $parent;
     }

--- a/src/Strategy/MakeWellFormed.hack
+++ b/src/Strategy/MakeWellFormed.hack
@@ -213,7 +213,6 @@ class HTMLPurifier_Strategy_MakeWellFormed extends HTMLPurifier\HTMLPurifier_Str
                     $this->token = $token;
                 }
 
-
                 // punt!
                 $reprocess = false;
                 continue;

--- a/src/Token/Empty.hack
+++ b/src/Token/Empty.hack
@@ -14,4 +14,3 @@ class HTMLPurifier_Token_Empty extends HTMLPurifier_Token_Tag {
     }
 }
 
-

--- a/src/TokenFactory.hack
+++ b/src/TokenFactory.hack
@@ -1,7 +1,6 @@
 /* Created by Nikita Ashok and Jake Polacek on 08/04/2020 */
 namespace HTMLPurifier;
 
-
 /**
  * Factory for token generation.
  */
@@ -40,6 +39,5 @@ class HTMLPurifier_TokenFactory {
     public function createComment(string $data): Token\HTMLPurifier_Token_Comment {
         return new Token\HTMLPurifier_Token_Comment($data);
     }
-
 
 }

--- a/tests/HTMLPurifierTest.hack
+++ b/tests/HTMLPurifierTest.hack
@@ -241,7 +241,6 @@ class HTMLPurifierTest extends HackTest {
 		echo "finished.\n\n";
 	}
 
-
 	public function testSanitizeHtmlWithIframeForVideoPolicySet(): void {
 		echo "\nrunning testSanitizeHtmlWithIframeForVideoPolicySet()...";
 		//porting over first config classes....
@@ -250,7 +249,6 @@ class HTMLPurifierTest extends HackTest {
 			dict["iframe" => vec["title", "width", "height", "src", "allowfullscreen"]],
 		);
 		$purifier = new HTMLPurifier\HTMLPurifier($config, $policy);
-
 
 		$dirty_html = '<iframe src="https://www.example.com/watch?v=M84hFmNhTQU" height="364" width="576"></iframe>';
 		$clean_html = $purifier->purify($dirty_html);
@@ -536,7 +534,6 @@ class HTMLPurifierTest extends HackTest {
 		expect($clean_html)->toEqual($expected_html);
 		echo "finished.\n\n";
 	}
-
 
 	public function testAtagTargetAttribute(): void {
 		echo "\nrunning testAtagTargetAttribute()...";


### PR DESCRIPTION
###  Summary

This adds support for HHVM 4.102. There was only one typechecker issue due to a missing `// FALLTHROUGH` comment in a switch, which I've fixed.

Since HHVM 4.102 and 4.80 are both supported LTS releases, we run tests on both for now.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
