### PR TITLE
Fix null string comparison

### DIFF
--- a/src/Arborize.hack
+++ b/src/Arborize.hack
@@ -71,7 +71,7 @@ class HTMLPurifier_Arborize {
 				if ($level > 0) {
 					$tokens[] = $start;
 				}
-				if ($end !== NULL) {
+				if ($end is nonnull) {
 					if (C\contains_key($closingTokens, $level)) {
 						$closingTokens[$level]->push($end);
 					} else {

--- a/src/AttrDef/CSS/FontFamily.hack
+++ b/src/AttrDef/CSS/FontFamily.hack
@@ -97,7 +97,7 @@ class HTMLPurifier_AttrDef_CSS_FontFamily extends HTMLPurifier\HTMLPurifier_Attr
 
 			// $font is a pure representation of the font name
 
-			if ($allowed_fonts !== null && !C\contains_key($allowed_fonts, $font)) {
+			if ($allowed_fonts is nonnull && !C\contains_key($allowed_fonts, $font)) {
 				continue;
 			}
 

--- a/src/AttrDef/CSS/Length.hack
+++ b/src/AttrDef/CSS/Length.hack
@@ -24,8 +24,8 @@ class HTMLPurifier_AttrDef_CSS_Length extends HTMLPurifier\HTMLPurifier_AttrDef 
 	 * @param HTMLPurifier_Length|string $max Maximum length, or null for no bound. String is also acceptable.
 	 */
 	public function __construct(?string $min = null, ?string $max = null): void {
-		$this->min = $min !== null ? HTMLPurifier\HTMLPurifier_Length::make($min) : null;
-		$this->max = $max !== null ? HTMLPurifier\HTMLPurifier_Length::make($max) : null;
+		$this->min = $min is nonnull ? HTMLPurifier\HTMLPurifier_Length::make($min) : null;
+		$this->max = $max is nonnull ? HTMLPurifier\HTMLPurifier_Length::make($max) : null;
 	}
 
 	/**

--- a/src/AttrDef/HTML/Pixels.hack
+++ b/src/AttrDef/HTML/Pixels.hack
@@ -62,7 +62,7 @@ class HTMLPurifier_AttrDef_HTML_Pixels extends HTMLPurifier\HTMLPurifier_AttrDef
 		// crash operating systems, see <http://ha.ckers.org/imagecrash.html>
 		// WARNING, above link WILL crash you if you're using Windows
 
-		if ($this->max !== null && $int > $this->max) {
+		if ($this->max is nonnull && $int > $this->max) {
 			return (string)$this->max;
 		}
 		return (string)$int;

--- a/src/AttrValidator.hack
+++ b/src/AttrValidator.hack
@@ -115,7 +115,7 @@ class HTMLPurifier_AttrValidator {
 			}
 
 			// put the results into effect
-			if (($result === '' && $value !== '') || $result === null) {
+			if (($result === '' && $value !== '') || $result is null) {
 				// this is a generic error message that should replaced
 				// with more specific ones when possible
 				// if ($e) {

--- a/src/ChildDef/List.hack
+++ b/src/ChildDef/List.hack
@@ -84,7 +84,7 @@ class HTMLPurifier_ChildDef_List extends HTMLPurifier\HTMLPurifier_ChildDef {
 				// to handle non-list elements; non-list elements should
 				// not be appended to an existing li; only li created
 				// for non-list. This distinction is not currently made.
-				if ($current_li === null) {
+				if ($current_li is null) {
 					$current_li = new Node\HTMLPurifier_Node_Element('li');
 					$result[] = $current_li;
 					$current_li->children[] = $node;

--- a/src/Config.hack
+++ b/src/Config.hack
@@ -201,7 +201,7 @@ class HTMLPurifier_Config {
 				if ($def->setup && !$optimized) {
 					throw new \Exception("Cannot retrieve raw definition after it has already been setup");
 				}
-				if ($def->optimized === null) {
+				if ($def->optimized is null) {
 					throw new \Exception("Optimization status of definition is unknown");
 
 				}

--- a/src/ConfigSchema.hack
+++ b/src/ConfigSchema.hack
@@ -448,7 +448,7 @@ class HTMLPurifier_ConfigSchema {
 	public function instance(?HTMLPurifier_ConfigSchema $prototype = null): HTMLPurifier_ConfigSchema {
 		if ($prototype) {
 			$this->singleton = $prototype;
-		} else if ($this->singleton === null) {
+		} else if ($this->singleton is null) {
 			$this->singleton = HTMLPurifier_ConfigSchema::makeFromSerial();
 		}
 		return $this->singleton;

--- a/src/Definition/CSSDefinition.hack
+++ b/src/Definition/CSSDefinition.hack
@@ -489,7 +489,7 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier\HTMLPurifier_Definition {
 		// setup allowed elements
 		$support = "(for information on implementing this, see the "."support forums) ";
 		$allowed_properties = $config->def->defaults['CSS.AllowedProperties'];
-		if ($allowed_properties !== null) {
+		if ($allowed_properties is nonnull) {
 			foreach ($this->info as $name => $d) {
 				if (C\contains_key($allowed_properties, $name) && !$allowed_properties[$name]) {
 					unset($this->info[$name]);
@@ -504,7 +504,7 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier\HTMLPurifier_Definition {
 		}
 
 		$forbidden_properties = $config->def->defaults['CSS.ForbiddenProperties'];
-		if ($forbidden_properties !== null) {
+		if ($forbidden_properties is nonnull) {
 			foreach ($this->info as $name => $d) {
 				if (C\contains_key($forbidden_properties, $name)) {
 					unset($this->info[$name]);

--- a/src/DefinitionCache/Serializer.hack
+++ b/src/DefinitionCache/Serializer.hack
@@ -274,7 +274,7 @@ class HTMLPurifier_DefinitionCache_Serializer {
 		if ($result !== false) {
 			// set permissions of the new file (no execute)
 			$chmod = $config->def->defaults['Cache.SerializerPermissions'];
-			if ($chmod !== null) {
+			if ($chmod is nonnull) {
 				// \chmod($file, $chmod & 0666);
 			}
 		}
@@ -287,7 +287,7 @@ class HTMLPurifier_DefinitionCache_Serializer {
 	private function _prepareDir(HTMLPurifier\HTMLPurifier_Config $config): bool {
 		$directory = $this->generateDirectoryPath($config);
 		$chmod = $config->def->defaults['Cache.SerializerPermissions'];
-		if ($chmod === null) {
+		if ($chmod is null) {
 			if (!\mkdir($directory) && !\is_dir($directory)) {
 				// trigger_error(
 				//     'Could not create directory ' . $directory . '',
@@ -343,7 +343,7 @@ class HTMLPurifier_DefinitionCache_Serializer {
 			// );
 			return false;
 		}
-		if (\function_exists('posix_getuid') && $chmod !== null) {
+		if (\function_exists('posix_getuid') && $chmod is nonnull) {
 			// POSIX system, we can give more specific advice
 			if (\fileowner($dir) === \posix_getuid()) {
 				// we can chmod it ourselves

--- a/src/Encoder.hack
+++ b/src/Encoder.hack
@@ -341,7 +341,7 @@ class HTMLPurifier_Encoder {
 	public static function iconvAvailable(): bool {
 		// statics are not permitted in Hack. Making a class with a single static is the work around
 		// I beleive this to be what Scott was referring to in #help-hacklang
-		if (StaticIconv::$iconv_bool === null) {
+		if (StaticIconv::$iconv_bool is null) {
 			StaticIconv::$iconv_bool = \function_exists('iconv') &&
 				self::testIconvTruncateBug() != self::ICONV_UNUSABLE;
 		}
@@ -360,7 +360,7 @@ class HTMLPurifier_Encoder {
 		if ($encoding === 'utf-8') {
 			return $str;
 		}
-		if (StaticIconv::$iconv_bool === null) {
+		if (StaticIconv::$iconv_bool is null) {
 			StaticIconv::$iconv_bool = self::iconvAvailable();
 		}
 		if (StaticIconv::$iconv_bool && !$config->def->defaults['Test.ForceNoIconv']) {
@@ -408,7 +408,7 @@ class HTMLPurifier_Encoder {
 		if ($encoding === 'utf-8') {
 			return $str;
 		}
-		if (StaticIconv::$iconv_bool === null) {
+		if (StaticIconv::$iconv_bool is null) {
 			StaticIconv::$iconv_bool = self::iconvAvailable();
 		}
 		if (StaticIconv::$iconv_bool && !$config->def->defaults['Test.ForceNoIconv']) {
@@ -496,7 +496,7 @@ class HTMLPurifier_Encoder {
 	 * paying attention to the error code, iconv becomes unusable.
 	 */
 	public static function testIconvTruncateBug(): int {
-		if (StaticCode::$code === null) {
+		if (StaticCode::$code is null) {
 			// better not use iconv, otherwise infinite loop!
 			$unsafe_iconv = self::unsafeIconv('utf-8', 'ascii//IGNORE', "\xCE\xB1".Str\repeat('a', 9000));
 			$count = Str\length($unsafe_iconv);

--- a/src/HTMLModuleManager.hack
+++ b/src/HTMLModuleManager.hack
@@ -403,7 +403,7 @@ class HTMLPurifier_HTMLModuleManager {
 
 		// setup global state variables
 		$def = null;
-		if ($trusted === null) {
+		if ($trusted is null) {
 			$trusted = $this->trusted;
 		}
 

--- a/src/Injector/AutoParagraph.hack
+++ b/src/Injector/AutoParagraph.hack
@@ -345,7 +345,7 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier\HTMLPurifier_Inje
 		$current = TypeAssert\matches<HTMLPurifier\HTMLPurifier_Token>($this->currentToken);
 		while ($this->forwardUntilEndToken(inout $i, inout $current, inout $nesting)) {
 			$result = $this->_checkNeedsP($current);
-			if ($result !== null) {
+			if ($result is nonnull) {
 				$ok = $result;
 				break;
 			}

--- a/src/LanguageFactory.hack
+++ b/src/LanguageFactory.hack
@@ -58,9 +58,9 @@ class HTMLPurifier_LanguageFactory {
 	*/
 	public static function instance(?HTMLPurifier_LanguageFactory $prototype = null): HTMLPurifier_LanguageFactory {
 		$instance = null;
-		if ($prototype !== null) {
+		if ($prototype is nonnull) {
 			$instance = $prototype;
-		} else if ($instance === null || $prototype == true) {
+		} else if ($instance is null || $prototype == true) {
 			$instance = new HTMLPurifier_LanguageFactory();
 		}
 		return $instance;

--- a/src/Length.hack
+++ b/src/Length.hack
@@ -120,7 +120,7 @@ class HTMLPurifier_Length {
 	 * Returns true if this length unit is valid.
 	 */
 	public function isValid(HTMLPurifier_Config $config, HTMLPurifier_Context $context): bool {
-		if ($this->isValid === null) {
+		if ($this->isValid is null) {
 			$this->isValid = $this->validate($config, $context);
 		}
 		return $this->isValid;

--- a/src/Strategy/MakeWellFormed.hack
+++ b/src/Strategy/MakeWellFormed.hack
@@ -105,7 +105,7 @@ class HTMLPurifier_Strategy_MakeWellFormed extends HTMLPurifier\HTMLPurifier_Str
 		unset($injectors['Custom']); // special case
 		foreach ($injectors as $injector => $b) {
 			// XXX: Fix with a legitimate lookup table of enabled filters
-			if (Str\search($injector, '.') !== null) {
+			if (Str\search($injector, '.') is nonnull) {
 				continue;
 			}
 			if (!$b) {
@@ -235,7 +235,7 @@ class HTMLPurifier_Strategy_MakeWellFormed extends HTMLPurifier\HTMLPurifier_Str
 							// See Note [Injector skips]
 							continue;
 						}
-						if ($token->rewind !== null && $token->rewind !== $i) {
+						if ($token->rewind is nonnull && $token->rewind !== $i) {
 							continue;
 						}
 						$r = $token;
@@ -317,7 +317,7 @@ class HTMLPurifier_Strategy_MakeWellFormed extends HTMLPurifier\HTMLPurifier_Str
 						// See Note [Injector skips]
 						continue;
 					}
-					if ($token->rewind !== null && $token->rewind !== $i) {
+					if ($token->rewind is nonnull && $token->rewind !== $i) {
 						continue;
 					}
 					$r = $token;
@@ -392,7 +392,7 @@ class HTMLPurifier_Strategy_MakeWellFormed extends HTMLPurifier\HTMLPurifier_Str
 						// See Note [Injector skips]
 						continue;
 					}
-					if ($token->rewind !== null && $token->rewind !== $i) {
+					if ($token->rewind is nonnull && $token->rewind !== $i) {
 						continue;
 					}
 					$r = $token;

--- a/src/Strategy/RemoveForeignElements.hack
+++ b/src/Strategy/RemoveForeignElements.hack
@@ -180,7 +180,7 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier\HTMLPurif
 					if (
 						$trusted ||
 						C\contains($comment_lookup, Str\trim($token->data)) ||
-						($comment_regexp !== null && \preg_match($comment_regexp, Str\trim($token->data)))
+						($comment_regexp is nonnull && \preg_match($comment_regexp, Str\trim($token->data)))
 					) {
 						// OK good
 						if ($e) {

--- a/src/Strategy/RemoveForeignElements.hack
+++ b/src/Strategy/RemoveForeignElements.hack
@@ -41,7 +41,7 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier\HTMLPurif
 		$trusted = $config->def->defaults['HTML.Trusted'];
 		$comment_lookup = $config->def->defaults['HTML.AllowedComments'];
 		$comment_regexp = $config->def->defaults['HTML.AllowedCommentsRegexp'];
-		$check_comments = $comment_lookup !== vec<string>[] || $comment_regexp != null;
+		$check_comments = $comment_lookup !== vec<string>[] || $comment_regexp is nonnull;
 
 		$remove_script_contents = $config->def->defaults['Core.RemoveScriptContents'];
 		$hidden_elements = $config->def->defaults['Core.HiddenElements'];

--- a/src/URI.hack
+++ b/src/URI.hack
@@ -252,7 +252,7 @@ class HTMLPurifier_URI {
 	 * @return bool
 	 */
 	public function isLocal(HTMLPurifier_Config $config, HTMLPurifier_Context $_context): bool {
-		if ($this->host === null) {
+		if ($this->host is null) {
 			return true;
 		}
 		$uri_def = TypeAssert\instance_of(Definition\HTMLPurifier_URIDefinition::class, $config->getURIDefinition());

--- a/src/URIFilter/SafeIframe.hack
+++ b/src/URIFilter/SafeIframe.hack
@@ -67,7 +67,7 @@ class HTMLPurifier_URIFilter_SafeIframe extends HTMLPurifier\HTMLPurifier_URIFil
 			return true;
 		}
 		// check if we actually have some allowlists enabled
-		if ($this->regexp === null) {
+		if ($this->regexp is null) {
 			return false;
 		}
 		// actually check the allowlists

--- a/src/URIParser.hack
+++ b/src/URIParser.hack
@@ -51,7 +51,7 @@ class HTMLPurifier_URIParser {
 		$fragment = (8 < C\count($matches)) ? $matches[9] : '';
 
 		// further parse authority
-		if ($authority !== null) {
+		if ($authority is nonnull) {
 			$r_authority = "/^((.+?)@)?(\[[^\]]+\]|[^:]*)(:(\d*))?/";
 			$matches = vec[];
 			\preg_match_with_matches($r_authority, $authority, inout $matches);

--- a/src/URIScheme/data.hack
+++ b/src/URIScheme/data.hack
@@ -59,12 +59,12 @@ class HTMLPurifier_URIScheme_data extends HTMLPurifier\HTMLPurifier_URIScheme {
 				if (Str\slice($cur, 0, 8) == 'charset=') {
 					// doesn't match if there are arbitrary spaces, but
 					// whatever dude
-					if ($charset !== null) {
+					if ($charset is nonnull) {
 						continue;
 					} // garbage
 					$charset = Str\slice($cur, 8); // not used
 				} else {
-					if ($content_type !== null) {
+					if ($content_type is nonnull) {
 						continue;
 					} // garbage
 					$content_type = $cur;
@@ -73,10 +73,10 @@ class HTMLPurifier_URIScheme_data extends HTMLPurifier\HTMLPurifier_URIScheme {
 		} else {
 			$data = $result[0];
 		}
-		if ($content_type !== null && !C\contains_key($this->allowed_types, $content_type)) {
+		if ($content_type is nonnull && !C\contains_key($this->allowed_types, $content_type)) {
 			return false;
 		}
-		if ($charset !== null) {
+		if ($charset is nonnull) {
 			// error; we don't allow plaintext stuff
 			$charset = null;
 		}
@@ -130,7 +130,7 @@ class HTMLPurifier_URIScheme_data extends HTMLPurifier\HTMLPurifier_URIScheme {
 		$uri->port = 0;
 		$uri->fragment = '';
 		$uri->query = '';
-		$uri->path = (string)$content_type.";base64," . \base64_encode($raw_data);
+		$uri->path = (string)$content_type.";base64,".\base64_encode($raw_data);
 		return true;
 	}
 

--- a/src/URISchemeRegistry.hack
+++ b/src/URISchemeRegistry.hack
@@ -20,9 +20,9 @@ class HTMLPurifier_URISchemeRegistry {
 	 */
 	public static function instance(?HTMLPurifier_URISchemeRegistry $prototype = null): HTMLPurifier_URISchemeRegistry {
 		$instance = null;
-		if ($prototype !== null) {
+		if ($prototype is nonnull) {
 			$instance = $prototype;
-		} elseif ($instance === null || $prototype == true) {
+		} elseif ($instance is null || $prototype == true) {
 			$instance = new HTMLPurifier_URISchemeRegistry();
 		}
 		return $instance;

--- a/src/Zipper.hack
+++ b/src/Zipper.hack
@@ -51,7 +51,7 @@ class HTMLPurifier_Zipper<T> {
 	 */
 	public function toArray(?T $t = null): vec<T> {
 		$a = $this->front;
-		if ($t !== null) $a[] = $t;
+		if ($t is nonnull) $a[] = $t;
 		for ($i = C\count($this->back) - 1; $i >= 0; $i--) {
 			$a[] = $this->back[$i];
 		}
@@ -65,7 +65,7 @@ class HTMLPurifier_Zipper<T> {
 	 * exist in Hack
 	 */
 	public function next(?T $t): ?T {
-		if ($t !== null) {
+		if ($t is nonnull) {
 			$this->front[] = $t;
 		}
 		$ret = C\last($this->back);
@@ -92,7 +92,7 @@ class HTMLPurifier_Zipper<T> {
 	 * @return Original contents of new hole.
 	 */
 	public function prev(?T $t): ?T {
-		if ($t !== null) {
+		if ($t is nonnull) {
 			$this->back[] = $t;
 		}
 		$ret = C\last($this->front);
@@ -127,14 +127,14 @@ class HTMLPurifier_Zipper<T> {
 	* Insert element before hole.
 	*/
 	public function insertBefore(T $t): void {
-		if ($t !== NULL) $this->front[] = $t;
+		if ($t is nonnull) $this->front[] = $t;
 	}
 
 	/**
 	* Insert element after hole.
 	*/
 	public function insertAfter(T $t): void {
-		if ($t !== NULL) $this->back[] = $t;
+		if ($t is nonnull) $this->back[] = $t;
 	}
 
 	/**
@@ -167,7 +167,7 @@ class HTMLPurifier_Zipper<T> {
 		}
 		// insert
 		for ($i = C\count($replacement) - 1; $i >= 0; $i--) {
-			if ($r !== null) $this->insertAfter($r);
+			if ($r is nonnull) $this->insertAfter($r);
 			$r = $replacement[$i];
 		}
 		return tuple($old, $r);


### PR DESCRIPTION
###  Summary

The purpose of this PR is to address the issue of comparing null and string using equality. Any instances of `=== null` and `!== null` were replaced by `is null` and `is nonnull`, respectively.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
