### PR TITLE
Adding error handling to get more information

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ ubuntu ]
         hhvm:
           - '4.153'
-    runs-on: ${{matrix.os}}-latest
+    runs-on: ${{matrix.os}}-20.04
     steps:
       - uses: actions/checkout@v2
       # Runs a single command using the runners shell

--- a/src/Lexer.hack
+++ b/src/Lexer.hack
@@ -283,8 +283,14 @@ class HTMLPurifier_Lexer {
 	 */
 	public function extractBody(string $html): string {
 		$matches = vec[];
-		$result = \preg_match_with_matches('|(.*?)<body[^>]*>(.*)</body>|is', $html, inout $matches);
-		if ($result) {
+		$error = null;
+		$result = \preg_match_with_matches_and_error('|(.*?)<body[^>]*>(.*)</body>|is', $html, inout $matches, inout $error);
+		if ($error is nonnull) {
+			// Adding some better error tracing here to get more info out of what's wrong with the regex on line 287
+			// The error codes can be found here: https://github.com/facebook/hhvm/blob/c5da95da0bd1f0ba9524e6a6e020ab824c1e75b0/hphp/runtime/base/preg.h#L42
+			throw new \Error("Error in preg_match_with_matches_and_error: $error", \E_USER_WARNING);
+		}
+		else if ($result) {
 			// Make sure it's not in a comment
 			$comment_start = \strrpos($matches[1], '<!--');
 			$comment_end = \strrpos($matches[1], '-->');


### PR DESCRIPTION
###  Summary

We noticed some errors coming from `preg_match_with_matches` in `Lexer.hack`. Fred pointed out that we could switch to `preg_match_with_matches_and_error` in order to get additional information, so that's what this PR does

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/htmlsanitizer-hack/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
